### PR TITLE
chore: update build.gradle

### DIFF
--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -78,7 +78,7 @@ secrets {
 
     // A properties file containing default secret values. This file can be
     // checked in version control.
-    defaultPropertiesFileName = 'local.defaults.properties'
+    defaultPropertiesFileName = "local.defaults.properties"
 
     // Configure which keys should be ignored by the plugin by providing regular expressions.
     // "sdk.dir" is ignored by default.


### PR DESCRIPTION
Make the Secrets Gradle Plugin config snippet compatible with both Groovy and Kotlin build scripts by encasing strings in double quotes and only using single quotes for string interpolation.
