### PR TITLE
chore: add region tag to basic map demo and upgrade gradle

### DIFF
--- a/ApiDemos/java/app/build.gradle
+++ b/ApiDemos/java/app/build.gradle
@@ -58,9 +58,11 @@ dependencies {
 }
 
 secrets {
-    // To add your Maps API key to this project:
-    // 1. Open the root project's local.properties file
-    // 2. Add this line, where YOUR_API_KEY is your API key:
-    //        MAPS_API_KEY=YOUR_API_KEY
-    defaultPropertiesFileName 'local.defaults.properties'
+    // Optionally specify a different file name containing your secrets.
+    // The plugin defaults to "local.properties"
+    propertiesFileName = "secrets.properties"
+
+    // A properties file containing default secret values. This file can be
+    // checked in version control.
+    defaultPropertiesFileName = "local.defaults.properties"
 }

--- a/ApiDemos/java/app/src/gms/java/com/example/mapdemo/BasicMapDemoActivity.java
+++ b/ApiDemos/java/app/src/gms/java/com/example/mapdemo/BasicMapDemoActivity.java
@@ -27,6 +27,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to create a simple activity with a map and a marker on the map.
  */
+// [START maps_android_sample_basic_map]
 public class BasicMapDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
 
     @Override
@@ -49,3 +50,4 @@ public class BasicMapDemoActivity extends AppCompatActivity implements OnMapRead
         map.addMarker(new MarkerOptions().position(new LatLng(0, 0)).title("Marker"));
     }
 }
+// [END maps_android_sample_basic_map]

--- a/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:52:41 PDT 2023
+#Wed Apr 24 16:52:26 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -72,9 +72,11 @@ dependencies {
 }
 
 secrets {
-    // To add your Maps API key to this project:
-    // 1. Open the root project's local.properties file
-    // 2. Add this line, where YOUR_API_KEY is your API key:
-    //        MAPS_API_KEY=YOUR_API_KEY
-    defaultPropertiesFileName 'local.defaults.properties'
+    // Optionally specify a different file name containing your secrets.
+    // The plugin defaults to "local.properties"
+    propertiesFileName = "secrets.properties"
+
+    // A properties file containing default secret values. This file can be
+    // checked in version control.
+    defaultPropertiesFileName = "local.defaults.properties"
 }

--- a/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/BasicMapDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/BasicMapDemoActivity.kt
@@ -28,6 +28,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 /**
  * This shows how to create a simple activity with a map and a marker on the map.
  */
+// [START maps_android_sample_basic_map]
 class BasicMapDemoActivity : AppCompatActivity(), OnMapReadyCallback {
 
     val SYDNEY = LatLng(-33.862, 151.21)
@@ -52,3 +53,4 @@ class BasicMapDemoActivity : AppCompatActivity(), OnMapReadyCallback {
         }
     }
 }
+// [END maps_android_sample_basic_map]

--- a/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:47:14 PDT 2023
+#Wed Apr 24 16:50:10 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/WearOS/gradle/wrapper/gradle-wrapper.properties
+++ b/WearOS/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 22 15:50:30 PDT 2022
+#Wed Apr 24 17:08:14 PDT 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/snippets/gradle/wrapper/gradle-wrapper.properties
+++ b/snippets/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 16 15:40:50 PDT 2023
+#Wed Apr 24 16:53:30 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:41:41 PDT 2023
+#Wed Apr 24 17:05:07 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:43:28 PDT 2023
+#Wed Apr 24 17:05:38 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:44:41 PDT 2023
+#Wed Apr 24 17:06:19 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/java/StyledMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/StyledMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:46:02 PDT 2023
+#Wed Apr 24 17:07:25 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:37:14 PDT 2023
+#Wed Apr 24 17:04:17 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Oct 28 04:34:41 PDT 2023
+#Wed Apr 24 17:03:43 PDT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
-#Sat Oct 28 04:40:09 PDT 2023
+#Wed Apr 24 17:03:17 PDT 2024
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Add a region tag to support new code samples on developers.google.com

Upgrade gradle from 8.0 to 8.4 for all apps
