### PR TITLE
fix: correct getCapabilities calls in Kotlin

### DIFF
--- a/ApiDemos/java/app/src/main/res/values/strings.xml
+++ b/ApiDemos/java/app/src/main/res/values/strings.xml
@@ -206,7 +206,7 @@
     <!-- Advanced Markers Demo -->
     <string name="advanced_markers_demo_label">Advanced Markers</string>
     <string name="advanced_markers_demo_details">Showcases the usage of Advanced Markers.</string>
-    <string name="map_id">MY_MAP_ID</string>
+    <string name="map_id">DEMO_MAP_ID</string>
 
     <!--    Styling    -->
     <string name="styled_map_demo_label">Styled Map</string>

--- a/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/AdvancedMarkersDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/AdvancedMarkersDemoActivity.kt
@@ -63,8 +63,8 @@ class AdvancedMarkersDemoActivity : AppCompatActivity(), OnMapReadyCallback {
             moveCamera(CameraUpdateFactory.newLatLngZoom(SINGAPORE, ZOOM_LEVEL))
         }
 
-        val capabilities: MapCapabilities = map.mapCapabilities
-        Log.d(TAG, "are advanced marker enabled?" + capabilities.isAdvancedMarkersAvailable)
+        val capabilities: MapCapabilities = map.getMapCapabilities()
+        Log.d(TAG, "is advanced marker enabled? " + capabilities.isAdvancedMarkersAvailable)
 
         // This sample sets a view as the iconView for the Advanced Marker
         val textView = TextView(this)

--- a/ApiDemos/kotlin/app/src/main/res/values/strings.xml
+++ b/ApiDemos/kotlin/app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <!-- Advanced Markers Demo -->
     <string name="advanced_markers_demo_label">Advanced Markers</string>
     <string name="advanced_markers_demo_details">Showcases the usage of Advanced Markers.</string>
-    <string name="map_id">YOUR_MAP_ID</string>
+    <string name="map_id">DEMO_MAP_ID</string>
 
     <!-- Basic Map Demo -->
     <string name="basic_demo_label">Basic Map</string>


### PR DESCRIPTION
The app was crashing when using the existing getCapabilities calls in the AdvancedMarkerDemoActivity.kt.
