### PR TITLE
chore: improved git hook to add Google API Keys

### DIFF
--- a/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 24 16:52:26 PDT 2024
+#Tue May 07 08:42:16 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 24 16:50:10 PDT 2024
+#Tue May 07 08:42:40 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -5,8 +5,9 @@
 ## has been modified. Git Hooks are located in the folder .git/hooks
 
 FILE="local.defaults.properties"
+API_KEY_REGEX="AIza[0-9A-Za-z\-_]{35}"
 
-if ! grep -q "^MAPS_API_KEY=DEFAULT_API_KEY" "$FILE"; then
+if grep -qE "^MAPS_API_KEY=$API_KEY_REGEX" "$FILE"; then
     echo "Error: Commit rejected. Invalid content in $FILE."
     exit 1
 fi

--- a/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Tue May 07 08:43:21 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Tue May 07 08:46:26 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Tue May 07 08:48:57 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Tue May 07 08:50:46 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Tue May 07 08:51:23 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Tue May 07 08:52:32 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This PR improves the sample git hook to prevent a Google API Key from being committed.

The following paper describes the Google API Key Regex structure: https://www.ndss-symposium.org/wp-content/uploads/2019/02/ndss2019_04B-3_Meli_paper.pdf