### PR TITLE
chore: fixed build after the dependabot updates

### DIFF
--- a/ApiDemos/java/app/build.gradle
+++ b/ApiDemos/java/app/build.gradle
@@ -43,11 +43,10 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
-    implementation "androidx.recyclerview:recyclerview:1.3.1"
+    implementation "androidx.recyclerview:recyclerview:1.3.2"
     implementation 'com.android.volley:volley:1.2.1'
-
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.0.0"))
     // GMS
     gmsImplementation 'com.google.android.gms:play-services-maps:19.0.0'
 

--- a/ApiDemos/java/app/build.gradle
+++ b/ApiDemos/java/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId "com.example.mapdemo"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode 1
         versionName "1.0"

--- a/ApiDemos/java/build.gradle
+++ b/ApiDemos/java/build.gradle
@@ -19,12 +19,9 @@ allprojects {
         mavenLocal()
         google()
         mavenCentral()
-        flatDir {
-            dirs 'libs'
-        }
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 07 08:42:16 CEST 2024
+#Wed Jul 10 22:13:55 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdk 34
     defaultConfig {
         applicationId "com.example.kotlindemos"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode 1
         versionName "1.0"

--- a/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 07 08:42:40 CEST 2024
+#Wed Jul 10 22:13:18 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/WearOS/gradle/wrapper/gradle-wrapper.properties
+++ b/WearOS/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 24 17:08:14 PDT 2024
+#Wed Jul 10 22:24:53 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/snippets/app-compose/build.gradle
+++ b/snippets/app-compose/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.compose' version "2.0.0"
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
@@ -24,9 +25,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion '1.5.0'
-    }
+
 
     buildFeatures {
         compose true

--- a/snippets/gradle/wrapper/gradle-wrapper.properties
+++ b/snippets/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 01 14:29:09 CEST 2024
+#Wed Jul 10 22:14:33 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue May 07 08:43:21 CEST 2024
+#Wed Jul 10 22:15:41 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/java/MapWithMarker/app/build.gradle
+++ b/tutorials/java/MapWithMarker/app/build.gradle
@@ -26,8 +26,8 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.gms:play-services-maps:18.2.0'
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.google.android.gms:play-services-maps:19.0.0'
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.0.0"))
     implementation 'androidx.appcompat:appcompat:1.7.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'

--- a/tutorials/java/MapWithMarker/app/build.gradle
+++ b/tutorials/java/MapWithMarker/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 34
     defaultConfig {
         applicationId "com.example.mapwithmarker"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode 1
         versionName "1.0"

--- a/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue May 07 08:46:26 CEST 2024
+#Wed Jul 10 22:16:57 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/java/Polygons/app/build.gradle
+++ b/tutorials/java/Polygons/app/build.gradle
@@ -26,9 +26,9 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.google.android.gms:play-services-maps:19.0.0'
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.0.0"))
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'

--- a/tutorials/java/Polygons/build.gradle
+++ b/tutorials/java/Polygons/build.gradle
@@ -21,6 +21,6 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue May 07 08:48:57 CEST 2024
+#Wed Jul 10 22:17:21 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/java/StyledMap/app/build.gradle
+++ b/tutorials/java/StyledMap/app/build.gradle
@@ -30,9 +30,9 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.google.android.gms:play-services-maps:19.0.0'
+    implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.0.0"))
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'

--- a/tutorials/java/StyledMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/StyledMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 24 17:07:25 PDT 2024
+#Wed Jul 10 22:17:43 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue May 07 08:50:46 CEST 2024
+#Wed Jul 10 22:18:21 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/kotlin/MapWithMarker/app/build.gradle
+++ b/tutorials/kotlin/MapWithMarker/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 34
     defaultConfig {
         applicationId "com.example.mapwithmarker"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode 1
         versionName "1.0"

--- a/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue May 07 08:51:23 CEST 2024
+#Wed Jul 10 22:19:11 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Tue May 07 08:52:32 CEST 2024
+#Wed Jul 10 22:20:02 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The following PR fixes the builds, after the dependabot PRs that were automatically merged and introduce a compilation issue due to a misalignment on the AGP version.