### PR TITLE
chore: update all instructions to use secrets.properties

### DIFF
--- a/ApiDemos/java/app/build.gradle
+++ b/ApiDemos/java/app/build.gradle
@@ -57,8 +57,10 @@ dependencies {
 }
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -71,8 +71,10 @@ dependencies {
 }
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/googlemaps/android-samples)
-![Apache-2.0](https://img.shields.io/badge/license-Apache-blue) 
+![Apache-2.0](https://img.shields.io/badge/license-Apache-blue)
 [![Build demos](https://github.com/googlemaps/android-samples/workflows/Build%20demos/badge.svg)](https://github.com/googlemaps/android-samples/actions?query=workflow%3A%22Build+demos%22)
 [![Discord](https://img.shields.io/discord/676948200904589322)](https://discord.gg/hYsWbmk)
 
@@ -27,7 +27,7 @@ Pre-requisites
 
 * See each sample for pre-requisites.
 * All require up-to-date versions of the Android build tools and the Android support repository.
-* The demo apps require that you add your own Google Maps API key. See [Get an API Key](docs/GET_AN_API_KEY.md) docs for more instructions.
+* The demo apps require that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) docs for more instructions.
 
 Getting Started
 ---------------

--- a/WearOS/README.md
+++ b/WearOS/README.md
@@ -27,6 +27,8 @@ If prompted for a gradle configuration accept the default settings.
 
 Alternatively use the "gradlew build" command to build the project directly.
 
+See the [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) guide to get an API key.
+
 Open the `secrets.properties` file in your top-level directory, and then add the following code. Replace YOUR_API_KEY with your API key. Store your key in this file because secrets.properties is excluded from being checked into a version control system.
 If the `secrets.properties` file does not exist, create it in the same folder as the `local.properties` file.
 
@@ -34,7 +36,6 @@ If the `secrets.properties` file does not exist, create it in the same folder as
 MAPS_API_KEY=YOUR_API_KEY
 ```
 
-See the [guide for adding an API key to your project](https://developers.google.com/maps/documentation/android-sdk/config#step_3_add_your_api_key_to_the_project).
 
 Support
 -------

--- a/WearOS/README.md
+++ b/WearOS/README.md
@@ -1,7 +1,7 @@
 Wear OS Sample
 ===================================
 
-This sample uses the [Google Maps Android API v2](https://developers.google.com/maps/documentation/android/)
+This sample uses the [Google Maps SDK for Android](https://developers.google.com/maps/documentation/android-sdk/wear)
 to display a map on Wear OS. It shows the basic setup required for a
 gradle-based Android Studio project that [supports ambient mode](https://developer.android.com/training/wearables/apps/always-on.html).
 
@@ -21,14 +21,20 @@ First download the samples by cloning this repository or downloading an archived
 snapshot. (See the options at the top of the page.)
 
 In Android Studio, use the "Import non-Android Studio project" or
-"Import Project" option. Next select the ApiDemos/ directory that you downloaded
+"Import Project" option. Next select the `WearOS/` directory that you downloaded
 from this repository.
 If prompted for a gradle configuration accept the default settings.
 
 Alternatively use the "gradlew build" command to build the project directly.
 
-Add your API key to the `local.properties` file and call it `GOOGLE_MAPS_API_KEY`.
-See the [quick guide to getting an API key](https://developers.google.com/maps/documentation/android-api/signup).
+Open the `secrets.properties` file in your top-level directory, and then add the following code. Replace YOUR_API_KEY with your API key. Store your key in this file because secrets.properties is excluded from being checked into a version control system.
+If the `secrets.properties` file does not exist, create it in the same folder as the `local.properties` file.
+
+```
+MAPS_API_KEY=YOUR_API_KEY
+```
+
+See the [guide for adding an API key to your project](https://developers.google.com/maps/documentation/android-sdk/config#step_3_add_your_api_key_to_the_project).
 
 Support
 -------

--- a/WearOS/build.gradle
+++ b/WearOS/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'com.android.application' version '8.5.0' apply false
+    id 'com.android.application' version '8.5.2' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
     id 'org.jetbrains.kotlin.android' version '2.0.0' apply false
 }

--- a/docs/GET_AN_API_KEY.md
+++ b/docs/GET_AN_API_KEY.md
@@ -1,8 +1,0 @@
-# Getting an API Key
-
-The demos found in this repository require an API key. To create and use an API key:
-
-  1. [Get a Maps API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key)
-  1. Open the file in the root directory of the sample called `local.properties` (by default, this file is **NOT** under version control)
-  1. Add a single line to `local.properties` that looks like `MAPS_API_KEY=YOUR_API_KEY`, where `YOUR_API_KEY` is the API key you obtained in the first step
-  1. Build and run

--- a/snippets/app-compose/build.gradle
+++ b/snippets/app-compose/build.gradle
@@ -63,8 +63,10 @@ dependencies {
 // [END maps_android_compose_dependency]
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/snippets/app-ktx/build.gradle
+++ b/snippets/app-ktx/build.gradle
@@ -54,8 +54,10 @@ dependencies {
 // [END maps_android_ktx_install_snippet]
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/snippets/app-places-ktx/build.gradle
+++ b/snippets/app-places-ktx/build.gradle
@@ -54,8 +54,10 @@ dependencies {
 // [END places_android_ktx_install_snippet]
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/snippets/app-rx/build.gradle
+++ b/snippets/app-rx/build.gradle
@@ -63,8 +63,10 @@ dependencies {
 // [END maps_android_maps_rx_install]
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/snippets/app-utils-ktx/build.gradle
+++ b/snippets/app-utils-ktx/build.gradle
@@ -52,8 +52,10 @@ dependencies {
 // [END maps_android_utils_ktx_install_snippet]
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/snippets/app-utils/build.gradle
+++ b/snippets/app-utils/build.gradle
@@ -57,8 +57,10 @@ dependencies {
 // [END maps_android_utils_install_snippet]
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -71,8 +71,10 @@ dependencies {
 
 // [START maps_android_secrets_gradle_plugin_config]
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
+    // To add your Maps API key to this project:
+    // 1. If the secrets.properties file does not exist, create it in the same folder as the local.properties file.
+    // 2. Add this line, where YOUR_API_KEY is your API key:
+    //        MAPS_API_KEY=YOUR_API_KEY
     propertiesFileName = "secrets.properties"
 
     // A properties file containing default secret values. This file can be

--- a/tutorials/java/CurrentPlaceDetailsOnMap/README.md
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/README.md
@@ -26,7 +26,7 @@ This sample uses the Gradle build system.
 1. If prompted for a gradle configuration, accept the default settings.
   Alternatively use the `gradlew build` command to build the project directly.
 
-This demo app requires that you add your own Google Maps API key. See [Get an API Key](../../../docs/GET_AN_API_KEY.md) for more instructions.
+This demo app requires that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) for more instructions.
 
 Support
 -------

--- a/tutorials/java/MapWithMarker/README.md
+++ b/tutorials/java/MapWithMarker/README.md
@@ -19,12 +19,12 @@ This sample uses the Gradle build system.
 
 1. Download the samples by cloning this repository or downloading an archived
   snapshot. (See the options at the top of the page.)
-1. In Android Studio, use "Open an existing Android Studio project". Next select the 
+1. In Android Studio, use "Open an existing Android Studio project". Next select the
   `tutorials/java/MapWithMarker` directory that you downloaded
 1. If prompted for a gradle configuration, accept the default settings.
   Alternatively use the `gradlew build` command to build the project directly.
 
-This demo app requires that you add your own Google Maps API key. See [Get an API Key](../../../docs/GET_AN_API_KEY.md) for more instructions.
+This demo app requires that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) for more instructions.
 
 Support
 -------

--- a/tutorials/java/Polygons/README.md
+++ b/tutorials/java/Polygons/README.md
@@ -23,7 +23,7 @@ This sample uses the Gradle build system.
 1. If prompted for a gradle configuration, accept the default settings.
   Alternatively use the `gradlew build` command to build the project directly.
 
-This demo app requires that you add your own Google Maps API key. See [Get an API Key](../../../docs/GET_AN_API_KEY.md) for more instructions.
+This demo app requires that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) for more instructions.
 
 Support
 -------

--- a/tutorials/java/StyledMap/README.md
+++ b/tutorials/java/StyledMap/README.md
@@ -23,7 +23,7 @@ This sample uses the Gradle build system.
 1. If prompted for a gradle configuration, accept the default settings.
   Alternatively use the "gradlew build" command to build the project directly.
 
-This demo app requires that you add your own Google Maps API key. See [Get an API Key](../../../docs/GET_AN_API_KEY.md) for more instructions.
+This demo app requires that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) for more instructions.
 
 Support
 -------

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/README.md
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/README.md
@@ -23,7 +23,7 @@ This sample uses the Gradle build system.
 1. If prompted for a gradle configuration, accept the default settings.
   Alternatively use the `gradlew build` command to build the project directly.
 
-This demo app requires that you add your own Google Maps API key. See [Get an API Key](../../../docs/GET_AN_API_KEY.md) for more instructions.
+This demo app requires that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) for more instructions.
 
 Support
 -------

--- a/tutorials/kotlin/MapWithMarker/README.md
+++ b/tutorials/kotlin/MapWithMarker/README.md
@@ -20,12 +20,12 @@ This sample uses the Gradle build system.
 
 1. Download the samples by cloning this repository or downloading an archived
   snapshot. (See the options at the top of the page.)
-1. In Android Studio, use "Open an existing Android Studio project". Next select the 
+1. In Android Studio, use "Open an existing Android Studio project". Next select the
   `tutorials/kotlin/MapWithMarker` directory that you downloaded
 1. If prompted for a gradle configuration, accept the default settings.
   Alternatively use the `gradlew build` command to build the project directly.
 
-This demo app requires that you add your own Google Maps API key. See [Get an API Key](../../../docs/GET_AN_API_KEY.md) for more instructions.
+This demo app requires that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) for more instructions.
 
 Support
 -------

--- a/tutorials/kotlin/Polygons/README.md
+++ b/tutorials/kotlin/Polygons/README.md
@@ -23,7 +23,7 @@ This sample uses the Gradle build system.
 1. If prompted for a gradle configuration, accept the default settings.
   Alternatively use the `gradlew build` command to build the project directly.
 
-This demo app requires that you add your own Google Maps API key. See [Get an API Key](../../../docs/GET_AN_API_KEY.md) for more instructions.
+This demo app requires that you add your own Google Maps API key. See [Get an API key](https://developers.google.com/maps/documentation/android-sdk/get-api-key) for more instructions.
 
 Support
 -------


### PR DESCRIPTION
Given new best practice to use secrets.properties instead of local.properties with Secrets Gradle Plugin, update related READMEs.