### PR TITLE
fix: fixed release step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Build and check
       run: |
         cd snippets
-        ./gradlew assembleGmsDebug lintGmsDebug
+        ./gradlew assembleDebug lintGmsDebug
 
   build-tutorials:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,12 @@ jobs:
       run: |
         echo "Generating ApiDemos (Java) APKs"
         cd $GITHUB_WORKSPACE/ApiDemos/java
-        ./gradlew assembleGms
+        ./gradlew assemble
         cp ./app/build/outputs/apk/gms/debug/app-gms-debug.apk $GITHUB_WORKSPACE/ApiDemos-java-gms-debug.apk
 
         echo "Generating Kotlin (Kotlin) APKs"
         cd $GITHUB_WORKSPACE/ApiDemos/kotlin
-        ./gradlew assembleGms
+        ./gradlew assemble
         cp ./app/build/outputs/apk/gms/debug/app-gms-debug.apk $GITHUB_WORKSPACE/ApiDemos-kotlin-gms-debug.apk
 
     - uses: actions/setup-node@v2

--- a/.releaserc
+++ b/.releaserc
@@ -6,14 +6,14 @@ plugins:
   - - "@google/semantic-release-replace-plugin"
     - replacements:
         - files:
-            - "./ApiDemos/java/app/build.gradle"
-            - "./ApiDemos/kotlin/app/build.gradle"
+            - "./ApiDemos/java/app/build.gradle.kts"
+            - "./ApiDemos/kotlin/app/build.gradle.kts"
           from: "versionName = \".*\""
           to: "versionName = \"${nextRelease.version}\""
   - - "@semantic-release/git"
     - assets:
-        - "./ApiDemos/java/app/build.gradle"
-        - "./ApiDemos/kotlin/app/build.gradle"
+        - "./ApiDemos/java/app/build.gradle.kts"
+        - "./ApiDemos/kotlin/app/build.gradle.kts"
   - - "@semantic-release/github"
     - assets:
         - "./ApiDemos-java-gms-debug.apk"


### PR DESCRIPTION
The following PR fixes the release step.

Since we recently migrated our Groovy Gradle files to Kotlin, the .releaserc file also needs to be updated to reflect the new path. Otherwise [subsequent releases will fail](https://github.com/googlemaps-samples/android-samples/actions/runs/10517638741/job/29142120467).