### PR TITLE
Cean sandbox

### DIFF
--- a/open-in-idx-template/idx-template.nix
+++ b/open-in-idx-template/idx-template.nix
@@ -17,8 +17,7 @@
     # Create a secrets.properties file in the repo
     touch $WS_NAME/secrets.properties
     
-    # Create a secrets.properties variable for each key type in the
-      local.defaults.properties file
+    # Create a secrets.properties variable for each key type in local.defaults.properties
     
     while IFS= read -r line || [[ -n "$line" ]]; do
       # Check that an "=" exists in the line

--- a/open-in-idx-template/idx-template.nix
+++ b/open-in-idx-template/idx-template.nix
@@ -26,7 +26,7 @@
         # Extract the variable name
         keyVar=$(echo "$line" | cut -d '=' -f 1)
         # Define new variable in secrets file
-        echo "$key=\"${apikey}\"" >> $WS_NAME/secrets.properties
+        echo "$keyVar=\"${apikey}\"" >> $WS_NAME/secrets.properties
       fi
     done < $WS_NAME/local.defaults.properties
 

--- a/open-in-idx-template/idx-template.nix
+++ b/open-in-idx-template/idx-template.nix
@@ -14,9 +14,21 @@
     chmod -R +w "$WS_NAME"
     mkdir -p "$WS_NAME/.idx/"
 
-    # Create a secrets.properties file in the repo and replace the MAPS_API_KEY property with said value
+    # Create a secrets.properties file in the repo
     touch $WS_NAME/secrets.properties
-    echo "MAPS_API_KEY=\"${apikey}\"" > $WS_NAME/secrets.properties
+    
+    # Create a secrets.properties variable for each key type in the
+      local.defaults.properties file
+    
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      # Check that an "=" exists in the line
+      if [[ $line == *"="* ]]; then
+        # Extract the variable name
+        keyVar=$(echo "$line" | cut -d '=' -f 1)
+        # Define new variable in secrets file
+        echo "$key=\"${apikey}\"" >> $WS_NAME/secrets.properties
+      fi
+    done < $WS_NAME/local.defaults.properties
 
     # We create a dev.nix that builds the subproject specified at template instantiation
     launch_activity=${launchactivity} j2 --format=env ${./devNix.j2} -o $WS_NAME/.idx/dev.nix


### PR DESCRIPTION
fix: remove newline from while loop comment to prevent template error.

Remove unintended newline in comment that caused bash to evaluate the file name as a command.