### PR TITLE
fix: Re-add MarkerDemoActivity in Kotlin sample

### DIFF
--- a/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/DemoDetailsList.kt
+++ b/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/DemoDetailsList.kt
@@ -115,7 +115,7 @@ class DemoDetailsList {
             DemoDetails(
                 R.string.markers_demo_label,
                 R.string.markers_demo_description,
-                MapColorSchemeActivity::class.java
+                MarkerDemoActivity::class.java
             ),
             DemoDetails(
                 R.string.multi_map_demo_label,


### PR DESCRIPTION
Re-add MarkerDemoActivity that was accidentally removed in https://github.com/googlemaps-samples/android-samples/commit/429748845447201869a02cf8888881a6142a0d6a
