### PR TITLE
feat: added material to samples

### DIFF
--- a/ApiDemos/java/app/src/main/AndroidManifest.xml
+++ b/ApiDemos/java/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@ limitations under the License.
         android:icon="@mipmap/ic_launcher"
         android:label="@string/demo_title"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/MaterialAppTheme">
 
         <!--
             To add your Maps API key to this project:

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/AdvancedMarkersDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/AdvancedMarkersDemoActivity.java
@@ -41,7 +41,7 @@ import com.google.android.gms.maps.model.PinConfig;
  * possibilities.
  */
 // [START maps_android_sample_marker_advanced]
-public class AdvancedMarkersDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class AdvancedMarkersDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private static final LatLng SINGAPORE = new LatLng(1.3521, 103.8198);
     private static final LatLng KUALA_LUMPUR = new LatLng(3.1390, 101.6869);
@@ -57,7 +57,6 @@ public class AdvancedMarkersDemoActivity extends AppCompatActivity implements On
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        EdgeToEdge.enable(this);
         setContentView(R.layout.advanced_markers_demo);
 
         SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
@@ -67,15 +66,7 @@ public class AdvancedMarkersDemoActivity extends AppCompatActivity implements On
         applyInsets(findViewById(R.id.map_container));
     }
 
-    private static void applyInsets(View container) {
-        ViewCompat.setOnApplyWindowInsetsListener(container,
-                (view, insets) -> {
-                    Insets innerPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-                    view.setPadding(innerPadding.left, innerPadding.top, innerPadding.right, innerPadding.bottom);
-                    return insets;
-                }
-        );
-    }
+
 
     @Override
     public void onMapReady(GoogleMap map) {

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/AdvancedMarkersDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/AdvancedMarkersDemoActivity.java
@@ -16,9 +16,14 @@ package com.example.mapdemo;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.View;
 import android.widget.TextView;
 
+import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -52,12 +57,24 @@ public class AdvancedMarkersDemoActivity extends AppCompatActivity implements On
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
         setContentView(R.layout.advanced_markers_demo);
 
         SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         if (mapFragment != null) {
             mapFragment.getMapAsync(this);
         }
+        applyInsets(findViewById(R.id.map_container));
+    }
+
+    private static void applyInsets(View container) {
+        ViewCompat.setOnApplyWindowInsetsListener(container,
+                (view, insets) -> {
+                    Insets innerPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+                    view.setPadding(innerPadding.left, innerPadding.top, innerPadding.right, innerPadding.bottom);
+                    return insets;
+                }
+        );
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/BackgroundColorCustomizationDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/BackgroundColorCustomizationDemoActivity.java
@@ -16,6 +16,8 @@ package com.example.mapdemo;
 
 import android.os.Bundle;
 import android.widget.CheckBox;
+
+import androidx.activity.EdgeToEdge;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import com.google.android.gms.common.internal.Preconditions;
@@ -29,8 +31,9 @@ import com.google.android.material.switchmaterial.SwitchMaterial;
 /**
  * This shows how to create a simple activity with a custom background color appiled to the map, and
  * add a marker on the map.
+ *
  */
-public class BackgroundColorCustomizationDemoActivity extends AppCompatActivity
+public class BackgroundColorCustomizationDemoActivity extends SamplesBaseActivity
     implements OnMapReadyCallback {
 
     @Override
@@ -43,6 +46,7 @@ public class BackgroundColorCustomizationDemoActivity extends AppCompatActivity
 
         Preconditions.checkNotNull(mapFragment)
             .getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     /**

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/BackgroundColorCustomizationDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/BackgroundColorCustomizationDemoActivity.java
@@ -24,6 +24,7 @@ import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.android.material.switchmaterial.SwitchMaterial;
 
 /**
  * This shows how to create a simple activity with a custom background color appiled to the map, and
@@ -52,7 +53,7 @@ public class BackgroundColorCustomizationDemoActivity extends AppCompatActivity
     public void onMapReady(GoogleMap map) {
         map.setMapType(GoogleMap.MAP_TYPE_NONE);
 
-        CheckBox mapTypeToggleCheckbox = (CheckBox) findViewById(R.id.map_type_toggle);
+        SwitchMaterial mapTypeToggleCheckbox = findViewById(R.id.map_type_toggle);
         mapTypeToggleCheckbox.setOnCheckedChangeListener(
             (view, isChecked) -> map.setMapType(isChecked ? GoogleMap.MAP_TYPE_NORMAL : GoogleMap.MAP_TYPE_NONE));
 

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/BackgroundColorCustomizationProgrammaticDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/BackgroundColorCustomizationProgrammaticDemoActivity.java
@@ -17,6 +17,8 @@ package com.example.mapdemo;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.widget.CheckBox;
+
+import androidx.activity.EdgeToEdge;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentTransaction;
@@ -31,7 +33,7 @@ import com.google.android.gms.maps.model.MarkerOptions;
  * This shows how to to instantiate a SupportMapFragment programmatically with a custom background
  * color applied to the map, and add a marker on the map.
  */
-public class BackgroundColorCustomizationProgrammaticDemoActivity extends AppCompatActivity
+public class BackgroundColorCustomizationProgrammaticDemoActivity extends SamplesBaseActivity
     implements OnMapReadyCallback {
 
     private static final String MAP_FRAGMENT_TAG = "map";
@@ -61,6 +63,7 @@ public class BackgroundColorCustomizationProgrammaticDemoActivity extends AppCom
             fragmentTransaction.commit();
         }
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/BasicMapDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/BasicMapDemoActivity.java
@@ -28,7 +28,7 @@ import androidx.appcompat.app.AppCompatActivity;
  * This shows how to create a simple activity with a map and a marker on the map.
  */
 // [START maps_android_sample_basic_map]
-public class BasicMapDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class BasicMapDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -38,6 +38,7 @@ public class BasicMapDemoActivity extends AppCompatActivity implements OnMapRead
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     /**

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/CameraClampingDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/CameraClampingDemoActivity.java
@@ -34,7 +34,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to constrain the camera to specific boundaries and zoom levels.
  */
-public class CameraClampingDemoActivity extends AppCompatActivity
+public class CameraClampingDemoActivity extends SamplesBaseActivity
         implements OnMapReadyCallback, OnCameraIdleListener {
 
     private static final String TAG = CameraClampingDemoActivity.class.getSimpleName();
@@ -81,6 +81,7 @@ public class CameraClampingDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
             (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/CameraDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/CameraDemoActivity.java
@@ -43,7 +43,7 @@ import com.google.android.gms.maps.model.PolylineOptions;
  * This shows how to change the camera position for the map.
  */
 // [START maps_camera_events]
-public class CameraDemoActivity extends AppCompatActivity implements
+public class CameraDemoActivity extends SamplesBaseActivity implements
         OnCameraMoveStartedListener,
         OnCameraMoveListener,
         OnCameraMoveCanceledListener,
@@ -97,6 +97,7 @@ public class CameraDemoActivity extends AppCompatActivity implements
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     // [START_EXCLUDE silent]

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/CameraDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/CameraDemoActivity.java
@@ -126,6 +126,7 @@ public class CameraDemoActivity extends AppCompatActivity implements
     }
 
     // [START_EXCLUDE silent]
+
     /**
      * When the map is not ready the CameraUpdateFactory cannot be used. This should be called on
      * all entry points that call methods on the Google Maps API.

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/CircleDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/CircleDemoActivity.java
@@ -55,7 +55,7 @@ import java.util.List;
 /**
  * This shows how to draw circles on a map.
  */
-public class CircleDemoActivity extends AppCompatActivity
+public class CircleDemoActivity extends SamplesBaseActivity
         implements OnSeekBarChangeListener, OnMarkerDragListener, OnMapLongClickListener,
         OnItemSelectedListener, OnMapReadyCallback {
 
@@ -205,6 +205,7 @@ public class CircleDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     private String[] getResourceStrings(int[] resourceIds) {

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/CloudBasedMapStylingDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/CloudBasedMapStylingDemoActivity.java
@@ -25,7 +25,7 @@ import com.google.android.gms.maps.SupportMapFragment;
  * to style a map using this method, see:
  * https://developers.google.com/maps/documentation/android-sdk/cloud-based-map-styling
  **/
-public class CloudBasedMapStylingDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class CloudBasedMapStylingDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private static final String MAP_TYPE_KEY = "map_type";
     private GoogleMap map;
@@ -46,6 +46,7 @@ public class CloudBasedMapStylingDemoActivity extends AppCompatActivity implemen
         mapFragment.getMapAsync(this);
 
         setUpButtonListeners();
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/DataDrivenBoundariesActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/DataDrivenBoundariesActivity.java
@@ -57,7 +57,7 @@ import java.util.Set;
  * https://developers.google.com/maps/documentation/android-sdk/dds-boundaries/overview
  */
 // [START maps_android_data_driven_styling_boundaries]
-public class DataDrivenBoundariesActivity extends AppCompatActivity implements OnMapReadyCallback,
+public class DataDrivenBoundariesActivity extends SamplesBaseActivity implements OnMapReadyCallback,
         FeatureLayer.OnFeatureClickListener, PopupMenu.OnMenuItemClickListener {
     private static final String TAG = DataDrivenBoundariesActivity.class.getName();
 
@@ -106,6 +106,7 @@ public class DataDrivenBoundariesActivity extends AppCompatActivity implements O
 
         // [START_EXCLUDE silent]
         setupBoundarySelectorButton();
+        applyInsets(findViewById(R.id.map_container));
         // [END_EXCLUDE]
     }
 
@@ -316,21 +317,6 @@ public class DataDrivenBoundariesActivity extends AppCompatActivity implements O
 
     private static int setAlphaValueOnColor(int color, float alpha) {
         return (color & 0x00ffffff) | (round(alpha * 255) << 24);
-    }
-
-    /**
-     * Applies insets to the container view to properly handle window insets.
-     *
-     * @param container the container view to apply insets to
-     */
-    private static void applyInsets(View container) {
-        ViewCompat.setOnApplyWindowInsetsListener(container,
-                (view, insets) -> {
-                    Insets innerPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-                    view.setPadding(innerPadding.left, innerPadding.top, innerPadding.right, innerPadding.bottom);
-                    return insets;
-                }
-        );
     }
 
     /**

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/DataDrivenDatasetStylingActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/DataDrivenDatasetStylingActivity.java
@@ -54,7 +54,7 @@ import java.util.Map;
  * This is meant to work with the datasets in the res/raw directory.
  */
 // [START maps_android_data_driven_styling_datasets]
-public class DataDrivenDatasetStylingActivity extends AppCompatActivity implements OnMapReadyCallback, FeatureLayer.OnFeatureClickListener {
+public class DataDrivenDatasetStylingActivity extends SamplesBaseActivity implements OnMapReadyCallback, FeatureLayer.OnFeatureClickListener {
     private record DataSet(
             String label,
             String datasetId,
@@ -109,7 +109,6 @@ public class DataDrivenDatasetStylingActivity extends AppCompatActivity implemen
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        EdgeToEdge.enable(this);
         setContentView(R.layout.data_driven_styling_demo);
 
         // [START_EXCLUDE silent]
@@ -130,16 +129,6 @@ public class DataDrivenDatasetStylingActivity extends AppCompatActivity implemen
         }
 
         applyInsets(findViewById(R.id.map_container));
-    }
-
-    private static void applyInsets(View container) {
-        ViewCompat.setOnApplyWindowInsetsListener(container,
-                (view, insets) -> {
-                    Insets innerPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-                    view.setPadding(innerPadding.left, innerPadding.top, innerPadding.right, innerPadding.bottom);
-                    return insets;
-                }
-        );
     }
 
     /**

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/DemoDetails.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/DemoDetails.java
@@ -35,10 +35,10 @@ public class DemoDetails {
     /**
      * The demo activity's class.
      */
-    public final Class<? extends AppCompatActivity> activityClass;
+    public final Class<? extends SamplesBaseActivity> activityClass;
 
     public DemoDetails(
-            int titleId, int descriptionId, Class<? extends AppCompatActivity> activityClass) {
+            int titleId, int descriptionId, Class<? extends SamplesBaseActivity> activityClass) {
         this.titleId = titleId;
         this.descriptionId = descriptionId;
         this.activityClass = activityClass;

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/EventsDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/EventsDemoActivity.java
@@ -32,7 +32,7 @@ import androidx.appcompat.app.AppCompatActivity;
  * This shows how to listen to some {@link GoogleMap} events.
  */
 // [START maps_android_sample_events]
-public class EventsDemoActivity extends AppCompatActivity
+public class EventsDemoActivity extends SamplesBaseActivity
         implements OnMapClickListener, OnMapLongClickListener, OnCameraIdleListener,
         OnMapReadyCallback {
 
@@ -51,6 +51,7 @@ public class EventsDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/GroundOverlayDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/GroundOverlayDemoActivity.java
@@ -39,7 +39,7 @@ import java.util.List;
 /**
  * This shows how to add a ground overlay to a map.
  */
-public class GroundOverlayDemoActivity extends AppCompatActivity
+public class GroundOverlayDemoActivity extends SamplesBaseActivity
         implements OnSeekBarChangeListener, OnMapReadyCallback,
         GoogleMap.OnGroundOverlayClickListener {
 
@@ -72,6 +72,7 @@ public class GroundOverlayDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/IndoorDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/IndoorDemoActivity.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * A demo activity showing how to use indoor.
  */
-public class IndoorDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class IndoorDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private GoogleMap map;
 
@@ -48,6 +48,7 @@ public class IndoorDemoActivity extends AppCompatActivity implements OnMapReadyC
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/LayersDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/LayersDemoActivity.java
@@ -46,7 +46,7 @@ import static com.google.android.gms.maps.GoogleMap.MAP_TYPE_TERRAIN;
 /**
  * Demonstrates the different base layers of a map.
  */
-public class LayersDemoActivity extends AppCompatActivity
+public class LayersDemoActivity extends SamplesBaseActivity
     implements OnItemSelectedListener, OnMapReadyCallback,
     ActivityCompat.OnRequestPermissionsResultCallback {
 
@@ -90,6 +90,7 @@ public class LayersDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
             (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/LiteDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/LiteDemoActivity.java
@@ -37,7 +37,7 @@ import androidx.appcompat.app.AppCompatActivity;
  * launch the Google Maps Mobile application, {@link com.google.android.gms.maps.CameraUpdate}s
  * and {@link com.google.android.gms.maps.model.Polygon}s.
  */
-public class LiteDemoActivity extends AppCompatActivity implements
+public class LiteDemoActivity extends SamplesBaseActivity implements
         OnMapAndViewReadyListener.OnGlobalLayoutAndMapReadyListener {
 
     private static final LatLng BRISBANE = new LatLng(-27.47093, 153.0235);
@@ -73,6 +73,7 @@ public class LiteDemoActivity extends AppCompatActivity implements
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         new OnMapAndViewReadyListener(mapFragment, this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     /**

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/LiteListDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/LiteListDemoActivity.java
@@ -40,7 +40,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * Note the use of the view holder pattern with the
  * {@link com.google.android.gms.maps.OnMapReadyCallback}.
  */
-public class LiteListDemoActivity extends AppCompatActivity {
+public class LiteListDemoActivity extends SamplesBaseActivity {
 
     private RecyclerView mRecyclerView;
 
@@ -61,6 +61,7 @@ public class LiteListDemoActivity extends AppCompatActivity {
         mRecyclerView.setLayoutManager(mLinearLayoutManager);
         mRecyclerView.setAdapter(new MapAdapter(LIST_LOCATIONS));
         mRecyclerView.setRecyclerListener(mRecycleListener);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     /** Create a menu to switch between Linear and Grid LayoutManager. */

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/LocationSourceDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/LocationSourceDemoActivity.java
@@ -34,7 +34,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to use a custom location source.
  */
-public class LocationSourceDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class LocationSourceDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     /**
      * A {@link LocationSource} which reports a new location whenever a user long presses the map
@@ -95,6 +95,7 @@ public class LocationSourceDemoActivity extends AppCompatActivity implements OnM
         SupportMapFragment mapFragment =
             (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/MainActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/MainActivity.java
@@ -34,7 +34,7 @@ import androidx.appcompat.app.AppCompatActivity;
  *
  * <p>The main layout lists the demonstrated features, with buttons to launch them.
  */
-public final class MainActivity extends AppCompatActivity {
+public final class MainActivity extends SamplesBaseActivity {
 
     private static final String TAG = MainActivity.class.getSimpleName();
 
@@ -86,5 +86,6 @@ public final class MainActivity extends AppCompatActivity {
                     startActivity(new Intent(view.getContext(), demo.activityClass));
                 });
         }
+        applyInsets(findViewById(R.id.map_container));
     }
 }

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/MapColorSchemeActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/MapColorSchemeActivity.java
@@ -27,7 +27,7 @@ import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.MapColorScheme;
 
-public class MapColorSchemeActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class MapColorSchemeActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private Button buttonLight;
     private Button buttonDark;
@@ -44,6 +44,7 @@ public class MapColorSchemeActivity extends AppCompatActivity implements OnMapRe
         buttonLight = findViewById(R.id.map_color_light_mode);
         buttonDark = findViewById(R.id.map_color_dark_mode);
         buttonFollowSystem = findViewById(R.id.map_color_follow_system_mode);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/MapInPagerDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/MapInPagerDemoActivity.java
@@ -31,7 +31,7 @@ import androidx.viewpager.widget.ViewPager;
  * This shows how to add a map to a ViewPager. Note the use of
  * {@link ViewGroup#requestTransparentRegion(View)} to reduce jankiness.
  */
-public class MapInPagerDemoActivity extends AppCompatActivity {
+public class MapInPagerDemoActivity extends SamplesBaseActivity {
 
     /** Called when the activity is first created. */
     @Override
@@ -46,6 +46,8 @@ public class MapInPagerDemoActivity extends AppCompatActivity {
         // This is required to avoid a black flash when the map is loaded.  The flash is due
         // to the use of a SurfaceView as the underlying view of the map.
         pager.requestTransparentRegion(pager);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     /** A simple fragment that displays a TextView. */

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/MarkerCloseInfoWindowOnRetapDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/MarkerCloseInfoWindowOnRetapDemoActivity.java
@@ -32,7 +32,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to close the info window when the currently selected marker is re-tapped.
  */
-public class MarkerCloseInfoWindowOnRetapDemoActivity extends AppCompatActivity implements
+public class MarkerCloseInfoWindowOnRetapDemoActivity extends SamplesBaseActivity implements
         OnMarkerClickListener,
         OnMapClickListener,
         OnMapAndViewReadyListener.OnGlobalLayoutAndMapReadyListener {
@@ -58,6 +58,8 @@ public class MarkerCloseInfoWindowOnRetapDemoActivity extends AppCompatActivity 
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         new OnMapAndViewReadyListener(mapFragment, this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/MarkerDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/MarkerDemoActivity.java
@@ -65,7 +65,7 @@ import java.util.Random;
  * This shows how to place markers on a map.
  */
 // [START maps_android_sample_marker]
-public class MarkerDemoActivity extends AppCompatActivity implements
+public class MarkerDemoActivity extends SamplesBaseActivity implements
         OnMarkerClickListener,
         OnInfoWindowClickListener,
         OnMarkerDragListener,
@@ -236,6 +236,8 @@ public class MarkerDemoActivity extends AppCompatActivity implements
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         new OnMapAndViewReadyListener(mapFragment, this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/MultiMapDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/MultiMapDemoActivity.java
@@ -22,11 +22,12 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to create a simple activity with multiple maps on screen.
  */
-public class MultiMapDemoActivity extends AppCompatActivity {
+public class MultiMapDemoActivity extends SamplesBaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.multimap_demo);
+        applyInsets(findViewById(R.id.map_container));
     }
 }

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/MyLocationDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/MyLocationDemoActivity.java
@@ -42,7 +42,7 @@ import android.widget.Toast;
  * permission is not granted, the Activity is finished with an error message.
  */
 // [START maps_android_sample_my_location]
-public class MyLocationDemoActivity extends AppCompatActivity
+public class MyLocationDemoActivity extends SamplesBaseActivity
     implements
     OnMyLocationButtonClickListener,
     OnMyLocationClickListener,
@@ -72,6 +72,7 @@ public class MyLocationDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
             (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/OptionsDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/OptionsDemoActivity.java
@@ -22,11 +22,12 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * An activity that creates a map with some initial options.
  */
-public final class OptionsDemoActivity extends AppCompatActivity {
+public final class OptionsDemoActivity extends SamplesBaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.options_demo);
+        applyInsets(findViewById(R.id.map_container));
     }
 }

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/PolygonDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/PolygonDemoActivity.java
@@ -48,7 +48,7 @@ import java.util.List;
  * This shows how to draw polygons on a map.
  */
 // [START maps_android_sample_polygons]
-public class PolygonDemoActivity extends AppCompatActivity
+public class PolygonDemoActivity extends SamplesBaseActivity
         implements OnSeekBarChangeListener, OnItemSelectedListener, OnMapReadyCallback {
 
     private static final LatLng CENTER = new LatLng(-20, 130);
@@ -130,6 +130,8 @@ public class PolygonDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
     // [START_EXCLUDE silent]
 

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/PolylineDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/PolylineDemoActivity.java
@@ -55,7 +55,7 @@ import java.util.List;
  * This shows how to draw polylines on a map.
  */
 // [START maps_android_sample_polylines]
-public class PolylineDemoActivity extends AppCompatActivity
+public class PolylineDemoActivity extends SamplesBaseActivity
         implements OnSeekBarChangeListener, OnItemSelectedListener, OnMapReadyCallback {
 
     // City locations for mutable polyline.
@@ -160,6 +160,8 @@ public class PolylineDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
     // [START_EXCLUDE silent]
 

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/ProgrammaticDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/ProgrammaticDemoActivity.java
@@ -29,7 +29,7 @@ import androidx.fragment.app.FragmentTransaction;
 /**
  * Demonstrates how to instantiate a SupportMapFragment programmatically and add a marker to it.
  */
-public class ProgrammaticDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class ProgrammaticDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private static final String MAP_FRAGMENT_TAG = "map";
 
@@ -54,6 +54,8 @@ public class ProgrammaticDemoActivity extends AppCompatActivity implements OnMap
             fragmentTransaction.commit();
         }
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/RawMapViewDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/RawMapViewDemoActivity.java
@@ -29,7 +29,7 @@ import androidx.appcompat.app.AppCompatActivity;
  * This shows how to create a simple activity with a raw MapView and add a marker to it. This
  * requires forwarding all the important lifecycle methods onto MapView.
  */
-public class RawMapViewDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class RawMapViewDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private MapView mMapView;
 
@@ -51,6 +51,8 @@ public class RawMapViewDemoActivity extends AppCompatActivity implements OnMapRe
         mMapView.onCreate(mapViewBundle);
 
         mMapView.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/RetainMapDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/RetainMapDemoActivity.java
@@ -29,7 +29,7 @@ import androidx.appcompat.app.AppCompatActivity;
  * This shows how to retain a map across activity restarts (e.g., from screen rotations), which can
  * be faster than relying on state serialization.
  */
-public class RetainMapDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class RetainMapDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -45,6 +45,8 @@ public class RetainMapDemoActivity extends AppCompatActivity implements OnMapRea
         }
 
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/SamplesBaseActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/SamplesBaseActivity.java
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example.mapdemo;
+
+
+import android.os.Bundle;
+import android.view.View;
+
+import androidx.activity.EdgeToEdge;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+public class SamplesBaseActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        EdgeToEdge.enable(this);
+    }
+
+    /**
+     * Applies insets to the container view to properly handle window insets.
+     *
+     * @param container the container view to apply insets to
+     */
+    protected static void applyInsets(View container) {
+        ViewCompat.setOnApplyWindowInsetsListener(container,
+                (view, insets) -> {
+                    Insets innerPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+                    view.setPadding(innerPadding.left, innerPadding.top, innerPadding.right, innerPadding.bottom);
+                    return insets;
+                }
+        );
+    }
+}

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/SaveStateDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/SaveStateDemoActivity.java
@@ -38,7 +38,7 @@ import java.util.Random;
  * This activity shows how to save the state of a MapFragment when the activity is recreated, like
  * after rotation of the device.
  */
-public class SaveStateDemoActivity extends AppCompatActivity {
+public class SaveStateDemoActivity extends SamplesBaseActivity {
 
     /** Default marker position when the activity is first created. */
     private static final LatLng DEFAULT_MARKER_POSITION = new LatLng(48.858179, 2.294576);
@@ -155,6 +155,7 @@ public class SaveStateDemoActivity extends AppCompatActivity {
             }
 
             getMapAsync(this);
+
         }
 
 

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/SnapshotDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/SnapshotDemoActivity.java
@@ -32,7 +32,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to take a snapshot of the map.
  */
-public class SnapshotDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class SnapshotDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     /**
      * Note that this may be null if the Google Play services APK is not available.
@@ -50,6 +50,8 @@ public class SnapshotDemoActivity extends AppCompatActivity implements OnMapRead
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/SplitStreetViewPanoramaAndMapDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/SplitStreetViewPanoramaAndMapDemoActivity.java
@@ -36,7 +36,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to create a simple activity with streetview and a map
  */
-public class SplitStreetViewPanoramaAndMapDemoActivity extends AppCompatActivity
+public class SplitStreetViewPanoramaAndMapDemoActivity extends SamplesBaseActivity
         implements OnMarkerDragListener, OnStreetViewPanoramaChangeListener {
 
     private static final String MARKER_POSITION_KEY = "MarkerPosition";
@@ -91,6 +91,7 @@ public class SplitStreetViewPanoramaAndMapDemoActivity extends AppCompatActivity
                         .draggable(true));
             }
         });
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaBasicDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaBasicDemoActivity.java
@@ -27,7 +27,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to create a simple activity with streetview
  */
-public class StreetViewPanoramaBasicDemoActivity extends AppCompatActivity {
+public class StreetViewPanoramaBasicDemoActivity extends SamplesBaseActivity {
 
     // George St, Sydney
     private static final LatLng SYDNEY = new LatLng(-33.87365, 151.20689);
@@ -51,5 +51,7 @@ public class StreetViewPanoramaBasicDemoActivity extends AppCompatActivity {
                         }
                     }
                 });
+
+        applyInsets(findViewById(R.id.map_container));
     }
 }

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaEventsDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaEventsDemoActivity.java
@@ -35,7 +35,7 @@ import com.google.android.gms.maps.model.StreetViewPanoramaOrientation;
 /**
  * This shows how to listen to some {@link StreetViewPanorama} events.
  */
-public class StreetViewPanoramaEventsDemoActivity extends AppCompatActivity
+public class StreetViewPanoramaEventsDemoActivity extends SamplesBaseActivity
         implements OnStreetViewPanoramaChangeListener, OnStreetViewPanoramaCameraChangeListener,
         OnStreetViewPanoramaClickListener, OnStreetViewPanoramaLongClickListener {
 
@@ -91,6 +91,8 @@ public class StreetViewPanoramaEventsDemoActivity extends AppCompatActivity
                         streetViewPanorama.setPosition(SYDNEY);
                     }
                 });
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaNavigationDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaNavigationDemoActivity.java
@@ -36,7 +36,7 @@ import androidx.appcompat.app.AppCompatActivity;
  * which can be adjusted dynamically
  */
 
-public class StreetViewPanoramaNavigationDemoActivity extends AppCompatActivity {
+public class StreetViewPanoramaNavigationDemoActivity extends SamplesBaseActivity {
 
     // George St, Sydney
     private static final LatLng SYDNEY = new LatLng(-33.87365, 151.20689);
@@ -82,6 +82,7 @@ public class StreetViewPanoramaNavigationDemoActivity extends AppCompatActivity 
                     }
                 });
         mCustomDurationBar = (SeekBar) findViewById(R.id.duration_bar);
+        applyInsets(findViewById(R.id.map_container));
     }
 
     /**

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaOptionsDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaOptionsDemoActivity.java
@@ -30,7 +30,7 @@ import com.google.android.gms.maps.model.StreetViewSource;
 /**
  * This shows how to create an activity with static streetview (all options have been switched off)
  */
-public class StreetViewPanoramaOptionsDemoActivity extends AppCompatActivity {
+public class StreetViewPanoramaOptionsDemoActivity extends SamplesBaseActivity {
 
     // Cole St, San Fran
     private static final LatLng SAN_FRAN = new LatLng(37.765927, -122.449972);
@@ -77,6 +77,8 @@ public class StreetViewPanoramaOptionsDemoActivity extends AppCompatActivity {
                         setPosition();
                     }
                 });
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     private void setPosition() {

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaViewDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/StreetViewPanoramaViewDemoActivity.java
@@ -28,7 +28,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * This shows how to create a simple activity with streetview
  */
-public class StreetViewPanoramaViewDemoActivity extends AppCompatActivity {
+public class StreetViewPanoramaViewDemoActivity extends SamplesBaseActivity {
 
     // George St, Sydney
     private static final LatLng SYDNEY = new LatLng(-33.87365, 151.20689);
@@ -58,6 +58,8 @@ public class StreetViewPanoramaViewDemoActivity extends AppCompatActivity {
             streetViewBundle = savedInstanceState.getBundle(STREETVIEW_BUNDLE_KEY);
         }
         streetViewPanoramaView.onCreate(streetViewBundle);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/StyledMapDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/StyledMapDemoActivity.java
@@ -38,7 +38,7 @@ import java.util.List;
 /**
  * This shows how to style a map with JSON.
  */
-public class StyledMapDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class StyledMapDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private GoogleMap mMap = null;
 
@@ -73,6 +73,8 @@ public class StyledMapDemoActivity extends AppCompatActivity implements OnMapRea
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/TagsDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/TagsDemoActivity.java
@@ -47,7 +47,7 @@ import com.google.android.gms.maps.model.PolylineOptions;
 /**
  * This shows how to use setTag/getTag on API objects.
  */
-public class TagsDemoActivity extends AppCompatActivity implements
+public class TagsDemoActivity extends SamplesBaseActivity implements
         OnCircleClickListener,
         OnGroundOverlayClickListener,
         OnMarkerClickListener,
@@ -101,6 +101,8 @@ public class TagsDemoActivity extends AppCompatActivity implements
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         new OnMapAndViewReadyListener(mapFragment, this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/TileCoordinateDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/TileCoordinateDemoActivity.java
@@ -36,7 +36,7 @@ import java.io.ByteArrayOutputStream;
 /**
  * This demonstrates tile overlay coordinates.
  */
-public class TileCoordinateDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class TileCoordinateDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,6 +46,8 @@ public class TileCoordinateDemoActivity extends AppCompatActivity implements OnM
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/TileOverlayDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/TileOverlayDemoActivity.java
@@ -38,7 +38,7 @@ import java.util.Locale;
 /**
  * This demonstrates how to add a tile overlay to a map.
  */
-public class TileOverlayDemoActivity extends AppCompatActivity
+public class TileOverlayDemoActivity extends SamplesBaseActivity
         implements OnSeekBarChangeListener, OnMapReadyCallback {
 
     private static final int TRANSPARENCY_MAX = 100;
@@ -62,6 +62,8 @@ public class TileOverlayDemoActivity extends AppCompatActivity
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/UiSettingsDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/UiSettingsDemoActivity.java
@@ -36,7 +36,7 @@ import android.widget.Toast;
 /**
  * This shows how UI settings can be toggled.
  */
-public class UiSettingsDemoActivity extends AppCompatActivity implements OnMapReadyCallback {
+public class UiSettingsDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
     private GoogleMap mMap;
 
@@ -67,6 +67,8 @@ public class UiSettingsDemoActivity extends AppCompatActivity implements OnMapRe
         SupportMapFragment mapFragment =
             (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     /**

--- a/ApiDemos/java/app/src/main/java/com/example/mapdemo/VisibleRegionDemoActivity.java
+++ b/ApiDemos/java/app/src/main/java/com/example/mapdemo/VisibleRegionDemoActivity.java
@@ -37,7 +37,7 @@ import androidx.appcompat.app.AppCompatActivity;
  * This shows how to use setPadding to allow overlays that obscure part of the map without
  * obscuring the map UI or copyright notices.
  */
-public class VisibleRegionDemoActivity extends AppCompatActivity implements
+public class VisibleRegionDemoActivity extends SamplesBaseActivity implements
         OnMapAndViewReadyListener.OnGlobalLayoutAndMapReadyListener {
 
     /**
@@ -72,6 +72,8 @@ public class VisibleRegionDemoActivity extends AppCompatActivity implements
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(R.id.map);
         new OnMapAndViewReadyListener(mapFragment, this);
+
+        applyInsets(findViewById(R.id.map_container));
     }
 
     @Override

--- a/ApiDemos/java/app/src/main/res/layout/advanced_markers_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/advanced_markers_demo.xml
@@ -11,17 +11,36 @@
  limitations under the License.
 -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
     <!--We need to add the map id to make advanced markers work. For more information,
     check out https://developers.google.com/maps/documentation/get-map-id#create-a-map-id. -->
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/advanced_markers_demo_label"
+        app:titleTextColor="?attr/colorOnPrimary" />
+
     <fragment
         android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar"
         map:backgroundColor="#fff0b2dd"
-        map:mapId="@string/map_id"
-        class="com.google.android.gms.maps.SupportMapFragment"/>
-</RelativeLayout>
+        map:mapId="@string/map_id" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/background_color_customization_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/background_color_customization_demo.xml
@@ -18,6 +18,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
+    android:id="@+id/map_container"
     android:layout_height="match_parent">
 
   <com.google.android.material.appbar.MaterialToolbar

--- a/ApiDemos/java/app/src/main/res/layout/background_color_customization_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/background_color_customization_demo.xml
@@ -14,28 +14,49 @@
  limitations under the License.
 -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-  <fragment
+
+  <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/top_bar"
+      style="@style/Widget.MaterialComponents.Toolbar.Primary"
+      android:layout_width="0dp"
+      android:layout_height="?attr/actionBarSize"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/background_color_customization_demo_label"
+      app:titleTextColor="?attr/colorOnPrimary" />
+
+  <androidx.fragment.app.FragmentContainerView
       android:id="@+id/map"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
       map:backgroundColor="#fff0b2dd"
-      class="com.google.android.gms.maps.SupportMapFragment"/>
-  <FrameLayout
+      class="com.google.android.gms.maps.SupportMapFragment"
+      app:layout_constraintTop_toBottomOf="@+id/top_bar"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"/>
+
+  <LinearLayout
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
-      android:background="#D000"
-      android:padding="5dp">
-    <CheckBox
+      android:orientation="horizontal"
+      android:layout_margin="16dp"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent">
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
         android:id="@+id/map_type_toggle"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:paddingRight="5dp"
-        android:checked="false"
-        android:text="@string/show_map_tiles"/>
-  </FrameLayout>
-</RelativeLayout>
+        android:layout_height="48dp"
+        android:text="@string/show_map_tiles"
+        android:checked="false"/>
+  </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/background_color_customization_programmatic_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/background_color_customization_programmatic_demo.xml
@@ -14,28 +14,65 @@
  limitations under the License.
 -->
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ you may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
-  <fragment
-      android:id="@+id/map"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      class="com.google.android.gms.maps.SupportMapFragment"/>
-  <FrameLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:background="#D000"
-      android:padding="5dp">
-    <CheckBox
-        android:id="@+id/map_type_toggle"
+    android:layout_height="match_parent">
+
+    <fragment
+        android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar" />
+
+    <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:paddingRight="5dp"
-        android:checked="false"
-        android:text="@string/show_map_tiles"/>
-  </FrameLayout>
-</FrameLayout>
+        android:background="#D000"
+        android:padding="5dp"
+        app:layout_constraintBottom_toBottomOf="@+id/map"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/map_type_toggle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:checked="false"
+            android:paddingEnd="5dp"
+            android:text="@string/show_map_tiles" />
+    </FrameLayout>
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/background_color_customization_programmatic_demo_label"
+        app:titleTextColor="?attr/colorOnPrimary" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/background_color_customization_programmatic_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/background_color_customization_programmatic_demo.xml
@@ -32,7 +32,7 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/container"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/basic_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/basic_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +13,30 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<!-- This can go anywhere in your layout (see other demos for some examples). -->
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/map"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    class="com.google.android.gms.maps.SupportMapFragment" />
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/basic_map_demo_label"
+        app:titleTextColor="?attr/colorOnPrimary" />
+
+    <fragment
+        android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/camera_clamping_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/camera_clamping_demo.xml
@@ -29,8 +29,27 @@
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/background_color_customization_demo_label"
         app:titleTextColor="?attr/colorOnPrimary" />
+    <fragment
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/container"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        map:cameraMaxZoomPreference="14.0"
+        map:cameraMinZoomPreference="10.0"
+        map:cameraTargetLat="37.421976"
+        map:cameraTargetLng="-122.084065"
+        map:cameraZoom="12"
+        map:latLngBoundsNorthEastLatitude="37.45"
+        map:latLngBoundsNorthEastLongitude="-122.05"
+        map:latLngBoundsSouthWestLatitude="37.4"
+        map:latLngBoundsSouthWestLongitude="-122.1" />
 
     <LinearLayout
+        android:background="@color/white"
         android:id="@+id/container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -44,21 +63,21 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_min_zoom"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="onSetMinZoomClamp"
                 android:text="@string/clamp_min_zoom" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_max_zoom"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="onSetMaxZoomClamp"
                 android:text="@string/clamp_max_zoom" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_zoom_reset"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -71,7 +90,7 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_latlng_adelaide"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -79,7 +98,7 @@
                 android:onClick="onClampToAdelaide"
                 android:text="@string/clamp_latlng_adelaide" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_latlng_pacific"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -87,7 +106,7 @@
                 android:onClick="onClampToPacific"
                 android:text="@string/clamp_latlng_pacific" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_latlng_reset"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -108,22 +127,4 @@
         </LinearLayout>
     </LinearLayout>
 
-    <fragment
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/container"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:id="@+id/map"
-        class="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        map:cameraMaxZoomPreference="14.0"
-        map:cameraMinZoomPreference="10.0"
-        map:cameraTargetLat="37.421976"
-        map:cameraTargetLng="-122.084065"
-        map:cameraZoom="12"
-        map:latLngBoundsNorthEastLatitude="37.45"
-        map:latLngBoundsNorthEastLongitude="-122.05"
-        map:latLngBoundsSouthWestLatitude="37.4"
-        map:latLngBoundsSouthWestLongitude="-122.1" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+  </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/camera_clamping_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/camera_clamping_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,86 +13,117 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:map="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical">
-  <LinearLayout
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:map="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/background_color_customization_demo_label"
+        app:titleTextColor="?attr/colorOnPrimary" />
+
     <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
-      <Button
-        android:id="@+id/clamp_min_zoom"
+        android:id="@+id/container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:onClick="onSetMinZoomClamp"
-        android:text="@string/clamp_min_zoom"/>
-      <Button
-        android:id="@+id/clamp_max_zoom"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="onSetMaxZoomClamp"
-        android:text="@string/clamp_max_zoom"/>
-      <Button
-        android:id="@+id/clamp_zoom_reset"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="onMinMaxZoomClampReset"
-        android:text="@string/clamp_zoom_reset"/>
+        android:orientation="vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/clamp_min_zoom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onSetMinZoomClamp"
+                android:text="@string/clamp_min_zoom" />
+
+            <Button
+                android:id="@+id/clamp_max_zoom"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onSetMaxZoomClamp"
+                android:text="@string/clamp_max_zoom" />
+
+            <Button
+                android:id="@+id/clamp_zoom_reset"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onMinMaxZoomClampReset"
+                android:text="@string/clamp_zoom_reset" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/clamp_latlng_adelaide"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:onClick="onClampToAdelaide"
+                android:text="@string/clamp_latlng_adelaide" />
+
+            <Button
+                android:id="@+id/clamp_latlng_pacific"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.5"
+                android:onClick="onClampToPacific"
+                android:text="@string/clamp_latlng_pacific" />
+
+            <Button
+                android:id="@+id/clamp_latlng_reset"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onLatLngClampReset"
+                android:text="@string/clamp_latlng_reset" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/camera_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/move_the_camera" />
+        </LinearLayout>
     </LinearLayout>
-    <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
-      <Button
-        android:id="@+id/clamp_latlng_adelaide"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="onClampToAdelaide"
-        android:layout_weight="0.5"
-        android:text="@string/clamp_latlng_adelaide"/>
-      <Button
-        android:id="@+id/clamp_latlng_pacific"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="onClampToPacific"
-        android:layout_weight="0.5"
-        android:text="@string/clamp_latlng_pacific"/>
-      <Button
-        android:id="@+id/clamp_latlng_reset"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:onClick="onLatLngClampReset"
-        android:text="@string/clamp_latlng_reset"/>
-    </LinearLayout>
-    <LinearLayout
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:orientation="horizontal">
-        <TextView
-          android:id="@+id/camera_text"
-          android:text="@string/move_the_camera"
-          android:layout_width="match_parent"
-          android:layout_height="wrap_content"/>
-    </LinearLayout>
-  </LinearLayout>
-  <fragment
-    android:id="@+id/map"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    class="com.google.android.gms.maps.SupportMapFragment"
-    map:cameraMinZoomPreference="10.0"
-    map:cameraMaxZoomPreference="14.0"
-    map:latLngBoundsSouthWestLatitude="37.4"
-    map:latLngBoundsSouthWestLongitude="-122.1"
-    map:latLngBoundsNorthEastLatitude="37.45"
-    map:latLngBoundsNorthEastLongitude="-122.05"
-    map:cameraTargetLat="37.421976"
-    map:cameraTargetLng="-122.084065"
-    map:cameraZoom="12"/>
-</LinearLayout>
+
+    <fragment
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/container"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent"
+        map:cameraMaxZoomPreference="14.0"
+        map:cameraMinZoomPreference="10.0"
+        map:cameraTargetLat="37.421976"
+        map:cameraTargetLng="-122.084065"
+        map:cameraZoom="12"
+        map:latLngBoundsNorthEastLatitude="37.45"
+        map:latLngBoundsNorthEastLongitude="-122.05"
+        map:latLngBoundsSouthWestLatitude="37.4"
+        map:latLngBoundsSouthWestLongitude="-122.1" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/camera_clamping_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/camera_clamping_demo.xml
@@ -16,6 +16,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/camera_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/camera_demo.xml
@@ -14,12 +14,33 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/background_color_customization_demo_label"
+        app:titleTextColor="?attr/colorOnPrimary" />
+    <fragment
+        android:id="@+id/map"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        class="com.google.android.gms.maps.SupportMapFragment" />
     <LinearLayout
+        android:background="@color/white"
+        android:baselineAligned="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar"
+        android:id="@+id/first_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -28,7 +49,7 @@
             android:layout_height="match_parent"
             android:orientation="vertical">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/stop_animation"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -51,7 +72,7 @@
             android:gravity="center_horizontal"
             android:layout_weight="1">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/scroll_left"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -61,7 +82,7 @@
                 android:layout_centerVertical="true"
                 android:text="@string/left_arrow" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/scroll_up"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -71,7 +92,7 @@
                 android:layout_toRightOf="@id/scroll_left"
                 android:text="@string/up_arrow" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/scroll_down"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -81,7 +102,7 @@
                 android:layout_toRightOf="@id/scroll_left"
                 android:text="@string/down_arrow" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/scroll_right"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -98,7 +119,7 @@
             android:layout_gravity="right"
             android:orientation="vertical">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/zoom_in"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -106,7 +127,7 @@
                 android:onClick="onZoomIn"
                 android:text="@string/zoom_in" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/zoom_out"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -121,7 +142,7 @@
             android:layout_height="fill_parent"
             android:layout_gravity="right">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/tilt_more"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -129,7 +150,7 @@
                 android:text="@string/tilt_more"
                 android:onClick="onTiltMore" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/tilt_less"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -140,10 +161,15 @@
     </LinearLayout>
 
     <LinearLayout
+        android:background="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/first_container"
+        android:id="@+id/second_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <CheckBox
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/duration_toggle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -159,10 +185,15 @@
     </LinearLayout>
 
     <LinearLayout
+        android:background="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/second_container"
+        android:id="@+id/third_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/sydney"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -170,7 +201,7 @@
             android:layout_weight="0.5"
             android:text="@string/go_to_sydney" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/bondi"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -179,9 +210,5 @@
             android:text="@string/go_to_bondi" />
     </LinearLayout>
 
-    <fragment
-        android:id="@+id/map"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        class="com.google.android.gms.maps.SupportMapFragment" />
-</LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/camera_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/camera_demo.xml
@@ -17,6 +17,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
+    android:id="@+id/map_container"
     android:layout_height="match_parent">
 
     <com.google.android.material.appbar.MaterialToolbar

--- a/ApiDemos/java/app/src/main/res/layout/circle_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/circle_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,96 +13,131 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/circle_demo_label"
+        app:titleTextColor="?attr/colorOnPrimary" />
+
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:text="@string/properties_circle" />
+        android:layout_height="0dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar">
 
-    <TableLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:stretchColumns="1">
-
-        <TableRow
+        <com.google.android.material.textview.MaterialTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/fill_hue" />
-            <SeekBar android:id="@+id/fillHueSeekBar" />
-        </TableRow>
+            android:gravity="center_horizontal"
+            android:text="@string/properties_circle" />
 
-        <TableRow
+        <TableLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/fill_alpha" />
-            <SeekBar android:id="@+id/fillAlphaSeekBar" />
-        </TableRow>
+            android:stretchColumns="1">
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/stroke_width" />
-            <SeekBar android:id="@+id/strokeWidthSeekBar" />
-        </TableRow>
-
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/stroke_hue" />
-            <SeekBar android:id="@+id/strokeHueSeekBar" />
-        </TableRow>
-
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/stroke_alpha" />
-            <SeekBar android:id="@+id/strokeAlphaSeekBar" />
-        </TableRow>
-
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView
-                android:text="@string/stroke_pattern"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-            <Spinner
-                android:id="@+id/strokePatternSpinner"
-                android:spinnerMode="dropdown"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-        </TableRow>
-
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <CheckBox
-                android:id="@+id/toggleClickability"
-                android:layout_width="wrap_content"
+            <TableRow
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:checked="true"
-                android:onClick="toggleClickability"
-                android:text="@string/clickable"/>
-        </TableRow>
+                android:gravity="center_vertical">
 
-    </TableLayout>
+                <com.google.android.material.textview.MaterialTextView android:text="@string/fill_hue" />
 
-    <fragment
-        android:id="@+id/map"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        class="com.google.android.gms.maps.SupportMapFragment"/>
+                <SeekBar android:id="@+id/fillHueSeekBar" />
+            </TableRow>
 
-</LinearLayout>
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.textview.MaterialTextView android:text="@string/fill_alpha" />
+
+                <SeekBar android:id="@+id/fillAlphaSeekBar" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.textview.MaterialTextView android:text="@string/stroke_width" />
+
+                <SeekBar android:id="@+id/strokeWidthSeekBar" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.textview.MaterialTextView android:text="@string/stroke_hue" />
+
+                <SeekBar android:id="@+id/strokeHueSeekBar" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.textview.MaterialTextView android:text="@string/stroke_alpha" />
+
+                <SeekBar android:id="@+id/strokeAlphaSeekBar" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/stroke_pattern" />
+
+                <Spinner
+                    android:id="@+id/strokePatternSpinner"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:spinnerMode="dropdown" />
+            </TableRow>
+
+            <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical">
+
+                <CheckBox
+                    android:id="@+id/toggleClickability"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:checked="true"
+                    android:onClick="toggleClickability"
+                    android:text="@string/clickable" />
+            </TableRow>
+
+        </TableLayout>
+
+        <fragment
+            android:id="@+id/map"
+            class="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/cloud_styling_basic_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/cloud_styling_basic_demo.xml
@@ -15,10 +15,24 @@
  limitations under the License.
 -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:map="http://schemas.android.com/apk/res-auto"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:map="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+  <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/top_bar"
+      android:layout_width="0dp"
+      android:layout_height="?attr/actionBarSize"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/cloud_styling_label"
+      app:titleTextColor="?attr/colorOnPrimary"
+      style="@style/Widget.MaterialComponents.Toolbar.Primary"
+      />
   <fragment
     android:id="@+id/map"
     class="com.google.android.gms.maps.SupportMapFragment"
@@ -62,4 +76,4 @@
         android:text="@string/lite_styling_terrain_mode" />
     </LinearLayout>
   </LinearLayout>
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/cloud_styling_basic_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/cloud_styling_basic_demo.xml
@@ -54,22 +54,22 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
       android:orientation="horizontal">
-      <Button
+      <com.google.android.material.button.MaterialButton
         android:id="@+id/styling_normal_mode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/lite_styling_normal_mode" />
-      <Button
+      <com.google.android.material.button.MaterialButton
         android:id="@+id/styling_satellite_mode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/lite_styling_satellite_mode" />
-      <Button
+      <com.google.android.material.button.MaterialButton
         android:id="@+id/styling_hybrid_mode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/lite_styling_hybrid_mode" />
-      <Button
+      <com.google.android.material.button.MaterialButton
         android:id="@+id/styling_terrain_mode"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/ApiDemos/java/app/src/main/res/layout/custom_info_contents.xml
+++ b/ApiDemos/java/app/src/main/res/layout/custom_info_contents.xml
@@ -16,6 +16,7 @@
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
+    android:id="@+id/map_container"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
 
@@ -24,7 +25,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginRight="5dp"
-        android:adjustViewBounds="true"></ImageView>
+        android:adjustViewBounds="true" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/ApiDemos/java/app/src/main/res/layout/custom_info_window.xml
+++ b/ApiDemos/java/app/src/main/res/layout/custom_info_window.xml
@@ -17,6 +17,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:id="@+id/map_container"
     android:background="@drawable/custom_info_bubble"
     android:orientation="horizontal">
 
@@ -25,7 +26,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginRight="5dp"
-        android:adjustViewBounds="true"></ImageView>
+        android:adjustViewBounds="true" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/ApiDemos/java/app/src/main/res/layout/events_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/events_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,32 +13,48 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/events_demo_label" />
+
     <fragment
         android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        class="com.google.android.gms.maps.SupportMapFragment" />
+        app:layout_constraintTop_toBottomOf="@+id/top_bar" />
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/white"
-        android:orientation="vertical">
+        android:layout_height="0dp"
+        android:orientation="vertical"
 
-        <TextView
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar">
+
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/tap_text"
-            android:text="@string/tap_instructions"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:text="@string/tap_instructions" />
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/camera_text"
-            android:text="@string/move_the_camera"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:text="@string/move_the_camera" />
     </LinearLayout>
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/feature.xml
+++ b/ApiDemos/java/app/src/main/res/layout/feature.xml
@@ -18,6 +18,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="5dp"
+    android:id="@+id/map_container"
     android:layout_weight="1"
     android:orientation="vertical">
 

--- a/ApiDemos/java/app/src/main/res/layout/ground_overlay_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/ground_overlay_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,18 +13,40 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/ground_overlay_demo_label" />
+
+    <fragment
+        android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintTop_toBottomOf="@+id/container" />
 
     <RelativeLayout
+        android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
-        android:padding="5dp">
+        android:padding="5dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar">
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/transparency_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -39,7 +60,7 @@
             android:layout_toEndOf="@+id/transparency_text"
             android:layout_toRightOf="@+id/transparency_text" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/switchImage"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -47,23 +68,14 @@
             android:onClick="switchImage"
             android:text="@string/switch_image" />
 
-        <CheckBox
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/toggleClickability"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignBottom="@+id/switchImage"
             android:layout_toEndOf="@+id/switchImage"
-            android:layout_toRightOf="@+id/switchImage"
             android:checked="true"
             android:onClick="toggleClickability"
             android:text="@string/clickable" />
-
     </RelativeLayout>
-
-    <fragment
-        android:id="@+id/map"
-        class="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/indoor_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/indoor_demo.xml
@@ -17,6 +17,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/map_container"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.google.android.material.appbar.MaterialToolbar

--- a/ApiDemos/java/app/src/main/res/layout/indoor_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/indoor_demo.xml
@@ -14,33 +14,46 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <RelativeLayout
-        android:layout_width="match_parent"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/indoor_demo_label" />
+
+    <fragment
+        android:id="@+id/map"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_weight="1">
+        class="com.google.android.gms.maps.SupportMapFragment"
+        app:layout_constraintTop_toBottomOf="@id/top_bar"
+        app:layout_constraintBottom_toTopOf="@+id/scrollView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
-        <fragment
-            android:id="@+id/map"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            class="com.google.android.gms.maps.SupportMapFragment" />
-        <!-- A small label at the top of the screen. -->
-        <TextView
-            android:id="@+id/top_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentTop="true" />
-    </RelativeLayout>
-    <!-- A set of test buttons. -->
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/top_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="100dp">
+        android:id="@+id/scrollView"
+        android:layout_width="0dp"
+        android:layout_height="100dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <TableLayout
             android:layout_width="match_parent"
@@ -48,15 +61,14 @@
             android:stretchColumns="1">
 
             <TableRow>
-
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/focused_bulding_info_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:onClick="onFocusedBuildingInfo"
                     android:text="@string/focused_building_info" />
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/toggle_level_picker_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -65,15 +77,14 @@
             </TableRow>
 
             <TableRow>
-
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/focused_level_info_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:onClick="onVisibleLevelInfo"
                     android:text="@string/focused_level_info" />
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/higher_level_button"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -82,4 +93,4 @@
             </TableRow>
         </TableLayout>
     </ScrollView>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/layers_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/layers_demo.xml
@@ -13,9 +13,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -37,7 +37,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/top_bar"/>
+        app:layout_constraintTop_toBottomOf="@id/top_bar" />
 
     <LinearLayout
         android:id="@+id/checkbox_container"

--- a/ApiDemos/java/app/src/main/res/layout/layers_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/layers_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,25 +13,41 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/layers_demo_label" />
+
     <fragment
         android:id="@+id/map"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        class="com.google.android.gms.maps.SupportMapFragment" />
-    <!-- A set of test checkboxes. -->
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar"/>
+
     <LinearLayout
+        android:id="@+id/checkbox_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignTop="@id/map"
-        android:padding="6dp"
         android:background="@color/white"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:padding="6dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/map">
 
         <Spinner
             android:id="@+id/layers_spinner"
@@ -58,16 +73,17 @@
             android:id="@+id/buildings"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:onClick="onBuildingsToggled"
             android:checked="true"
+            android:onClick="onBuildingsToggled"
             android:text="@string/buildings" />
 
         <CheckBox
             android:id="@+id/indoor"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:onClick="onIndoorToggled"
             android:checked="true"
+            android:onClick="onIndoorToggled"
             android:text="@string/indoor" />
     </LinearLayout>
-</RelativeLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/lite_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/lite_demo.xml
@@ -16,6 +16,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/tools"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/lite_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/lite_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,65 +13,68 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:map="http://schemas.android.com/apk/res-auto"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:map="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/lite_demo_label" />
 
     <TextView
         android:id="@+id/lite_demo_introtext"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/lite_demo_intro" />
+        android:text="@string/lite_demo_intro"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar" />
 
-
-    <!-- Change the camera of the map to show no markers -->
     <Button
         android:id="@+id/go_to_darwin"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:onClick="showDarwin"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/lite_demo_introtext"
-        android:text="@string/lite_go_to_darwin" />
+        android:text="@string/lite_go_to_darwin"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/lite_demo_introtext" />
 
-    <!-- Change the camera of the map to show one marker -->
     <Button
         android:id="@+id/go_to_adelaide"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:onClick="showAdelaide"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/go_to_darwin"
-        android:layout_toEndOf="@+id/go_to_australia"
-        android:layout_toRightOf="@+id/go_to_australia"
-        android:text="@string/lite_go_to_adelaide" />
+        android:text="@string/lite_go_to_adelaide"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/go_to_darwin" />
 
-    <!-- Change the camera of the map to show multiple markers -->
     <Button
         android:id="@+id/go_to_australia"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:onClick="showAustralia"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/go_to_adelaide"
-        android:layout_toEndOf="@+id/go_to_darwin"
-        android:layout_toRightOf="@+id/go_to_darwin"
-        android:text="@string/lite_go_to_australia" />
+        android:text="@string/lite_go_to_australia"
+        app:layout_constraintStart_toEndOf="@id/go_to_darwin"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/go_to_adelaide" />
 
-
-    <!-- MapFragment with lite mode enabled -->
     <fragment
         android:id="@+id/map"
         class="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_below="@id/go_to_australia"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/go_to_australia"
         map:liteMode="true" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/ApiDemos/java/app/src/main/res/layout/lite_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/lite_demo.xml
@@ -37,7 +37,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/top_bar" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/go_to_darwin"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -46,7 +46,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/lite_demo_introtext" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/go_to_adelaide"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -55,7 +55,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/go_to_darwin" />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/go_to_australia"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/ApiDemos/java/app/src/main/res/layout/lite_list_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/lite_list_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
     Copyright 2018 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +13,26 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<androidx.recyclerview.widget.RecyclerView
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/recycler_view"
-    android:scrollbars="vertical"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:map="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/lite_demo_label" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        app:layout_constraintTop_toBottomOf="@id/top_bar"
+        android:id="@+id/recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:scrollbars="vertical" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/lite_list_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/lite_list_demo.xml
@@ -15,7 +15,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:map="http://schemas.android.com/tools"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/lite_list_demo_row.xml
+++ b/ApiDemos/java/app/src/main/res/layout/lite_list_demo_row.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
     Copyright 2018 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,26 +13,31 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:map="http://schemas.android.com/apk/res-auto"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:map="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
     android:paddingTop="5dp">
 
     <TextView
         android:id="@+id/lite_listrow_text"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:textAppearance="?android:attr/textAppearanceLarge" />
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <!-- MapView in lite mode. Note that it needs to be initialised
-         programmatically before it can be used. -->
     <com.google.android.gms.maps.MapView
         android:id="@+id/lite_listrow_map"
         android:layout_width="match_parent"
         android:layout_height="150dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/lite_listrow_text"
         map:liteMode="true"
         map:mapType="none" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/ApiDemos/java/app/src/main/res/layout/lite_list_demo_row.xml
+++ b/ApiDemos/java/app/src/main/res/layout/lite_list_demo_row.xml
@@ -16,6 +16,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/tools"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingTop="5dp">

--- a/ApiDemos/java/app/src/main/res/layout/main.xml
+++ b/ApiDemos/java/app/src/main/res/layout/main.xml
@@ -13,21 +13,41 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/demo_title"
+        app:titleTextColor="?attr/colorOnPrimary" />
 
     <ListView
         android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar" />
 
     <TextView
         android:id="@+id/empty"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:text="@string/no_demos"
-        android:visibility="gone" />
-</LinearLayout>
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/map_color_scheme_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/map_color_scheme_demo.xml
@@ -14,6 +14,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/tools"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/map_color_scheme_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/map_color_scheme_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
     Copyright 2025 Google LLC
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -12,12 +11,22 @@
     limitations under the License.
  -->
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:map="http://schemas.android.com/apk/res-auto"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:map="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <!--We need to add the map id to make advanced markers work. For more information,
-    check out https://developers.google.com/maps/documentation/get-map-id#create-a-map-id. -->
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/map_color_scheme_demo_label" />
+
     <fragment
         android:id="@+id/map"
         class="com.google.android.gms.maps.SupportMapFragment"
@@ -32,27 +41,31 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="#D000"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/map_color_light_mode"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/map_color_light_mode" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/map_color_dark_mode"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/map_color_dark_mode" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/map_color_follow_system_mode"
             style="?android:attr/buttonBarButtonStyle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/map_color_follow_system_mode" />
     </LinearLayout>
-</RelativeLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/map_in_pager_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/map_in_pager_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +13,25 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<androidx.viewpager.widget.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/pager"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"></androidx.viewpager.widget.ViewPager>
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        app:title="@string/map_in_pager_demo_label"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.viewpager.widget.ViewPager
+        android:id="@+id/pager"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/map_in_pager_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/map_in_pager_demo.xml
@@ -15,6 +15,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/marker_close_info_window_on_retap_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/marker_close_info_window_on_retap_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,12 +14,14 @@
  limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical">
-  <fragment
-    android:id="@+id/map"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    class="com.google.android.gms.maps.SupportMapFragment"/>
+    android:orientation="vertical">
+
+    <fragment
+        android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
 </LinearLayout>

--- a/ApiDemos/java/app/src/main/res/layout/marker_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/marker_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,41 +13,21 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
-        android:id="@+id/top_text"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:lines="2"
-        android:text="@string/drag_melbourne" />
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/marker_demo_label" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <CheckBox
-            android:id="@+id/flat"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/flat"
-            android:textSize="14sp"
-            android:onClick="onToggleFlat" />
-
-        <TextView
-            android:layout_marginLeft="8dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/rotation" />
-
-        <SeekBar
-            android:id="@+id/rotationSeekBar"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content" />
-    </LinearLayout>
 
     <FrameLayout
         android:layout_width="match_parent"
@@ -56,14 +35,14 @@
 
         <fragment
             android:id="@+id/map"
+            class="com.google.android.gms.maps.SupportMapFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            class="com.google.android.gms.maps.SupportMapFragment" />
+            android:layout_height="match_parent" />
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="bottom|left"
+            android:layout_gravity="bottom|start"
             android:background="@color/white"
             android:orientation="vertical"
             android:padding="5dp">
@@ -72,14 +51,14 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="0.5"
                     android:onClick="onClearMap"
                     android:text="@string/clear_map" />
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="0.5"
@@ -94,17 +73,63 @@
 
                 <RadioButton
                     android:id="@+id/default_info_window"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:checked="true"
                     android:text="@string/default_info_window" />
 
                 <RadioButton
                     android:id="@+id/custom_info_contents"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:text="@string/custom_info_contents" />
 
                 <RadioButton
                     android:id="@+id/custom_info_window"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
                     android:text="@string/custom_info_window" />
             </RadioGroup>
         </LinearLayout>
     </FrameLayout>
-</LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="?attr/actionBarSize"
+        android:background="@color/white"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/top_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="2"
+            android:text="@string/drag_melbourne" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/flat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:onClick="onToggleFlat"
+                android:text="@string/flat"
+                android:textSize="14sp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:text="@string/rotation" />
+
+            <SeekBar
+                android:id="@+id/rotationSeekBar"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/ApiDemos/java/app/src/main/res/layout/marker_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/marker_demo.xml
@@ -15,6 +15,7 @@
 -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/multimap_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/multimap_demo.xml
@@ -14,66 +14,71 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:map="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/map_container"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/map_container1"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="0.5"
-        android:orientation="horizontal">
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/multi_map_demo_label" />
 
-        <fragment
-            android:id="@+id/map1"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="0.5"
-            class="com.google.android.gms.maps.SupportMapFragment"
-            map:cameraTargetLat="40.72"
-            map:cameraTargetLng="-74.00"
-            map:cameraZoom="8" />
+    <fragment
+        android:id="@+id/map1"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/map2"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar"
+        app:layout_constraintBottom_toTopOf="@+id/map3"
+        app:cameraTargetLat="40.72"
+        app:cameraTargetLng="-74.00"
+        app:cameraZoom="8" />
 
-        <fragment
-            android:id="@+id/map2"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="0.5"
-            class="com.google.android.gms.maps.SupportMapFragment"
-            map:cameraTargetLat="51.51"
-            map:cameraTargetLng="-0.12"
-            map:cameraZoom="8" />
-    </LinearLayout>
+    <fragment
+        android:id="@+id/map2"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toEndOf="@+id/map1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar"
+        app:layout_constraintBottom_toTopOf="@+id/map4"
+        app:cameraTargetLat="51.51"
+        app:cameraTargetLng="-0.12"
+        app:cameraZoom="8" />
 
-    <LinearLayout
-        android:id="@+id/map_container2"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="0.5"
-        android:orientation="horizontal">
+    <fragment
+        android:id="@+id/map3"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/map4"
+        app:layout_constraintTop_toBottomOf="@+id/map1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:cameraTargetLat="48.85"
+        app:cameraTargetLng="2.35"
+        app:cameraZoom="8" />
 
-        <fragment
-            android:id="@+id/map3"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="0.5"
-            class="com.google.android.gms.maps.SupportMapFragment"
-            map:cameraTargetLat="48.85"
-            map:cameraTargetLng="2.35"
-            map:cameraZoom="8" />
+    <fragment
+        android:id="@+id/map4"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintStart_toEndOf="@+id/map3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/map2"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:cameraTargetLat="35.69"
+        app:cameraTargetLng="139.69"
+        app:cameraZoom="8" />
 
-        <fragment
-            android:id="@+id/map4"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="0.5"
-            class="com.google.android.gms.maps.SupportMapFragment"
-            map:cameraTargetLat="35.69"
-            map:cameraTargetLng="139.69"
-            map:cameraZoom="8" />
-    </LinearLayout>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/multimap_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/multimap_demo.xml
@@ -16,6 +16,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/my_location_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/my_location_demo.xml
@@ -14,15 +14,29 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<!-- This can go anywhere in your layout (see other demos for some examples). -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:id="@+id/layout">
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/my_location_demo_label" />
 
     <fragment
         android:id="@+id/map"
         class="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</FrameLayout>
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/top_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/my_location_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/my_location_demo.xml
@@ -16,6 +16,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/polygon_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/polygon_demo.xml
@@ -16,6 +16,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/polygon_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/polygon_demo.xml
@@ -14,102 +14,116 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/polygon_demo_label" />
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:text="@string/properties_australia_polygon" />
+        app:layout_constraintTop_toBottomOf="@id/top_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/map">
 
-    <TableLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:stretchColumns="1">
-
-        <TableRow
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/fill_hue" />
-            <SeekBar android:id="@+id/fillHueSeekBar" />
-        </TableRow>
+            android:orientation="vertical">
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/fill_alpha" />
-            <SeekBar android:id="@+id/fillAlphaSeekBar" />
-        </TableRow>
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:text="@string/properties_australia_polygon" />
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/stroke_width" />
-            <SeekBar android:id="@+id/strokeWidthSeekBar" />
-        </TableRow>
+            <TableLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:stretchColumns="1">
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/stroke_hue" />
-            <SeekBar android:id="@+id/strokeHueSeekBar" />
-        </TableRow>
+                <TableRow>
+                    <TextView android:text="@string/fill_hue" />
+                    <SeekBar android:id="@+id/fillHueSeekBar" />
+                </TableRow>
 
-        <TableRow
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/stroke_alpha" />
-            <SeekBar android:id="@+id/strokeAlphaSeekBar" />
-        </TableRow>
+                <TableRow>
+                    <TextView android:text="@string/fill_alpha" />
+                    <SeekBar android:id="@+id/fillAlphaSeekBar" />
+                </TableRow>
 
-    </TableLayout>
+                <TableRow>
+                    <TextView android:text="@string/stroke_width" />
+                    <SeekBar android:id="@+id/strokeWidthSeekBar" />
+                </TableRow>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+                <TableRow>
+                    <TextView android:text="@string/stroke_hue" />
+                    <SeekBar android:id="@+id/strokeHueSeekBar" />
+                </TableRow>
 
-        <TextView
-            android:text="@string/stroke_joint_type"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-        <Spinner
-            android:id="@+id/strokeJointTypeSpinner"
-            android:spinnerMode="dropdown"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+                <TableRow>
+                    <TextView android:text="@string/stroke_alpha" />
+                    <SeekBar android:id="@+id/strokeAlphaSeekBar" />
+                </TableRow>
+            </TableLayout>
 
-        <TextView
-            android:text="@string/stroke_pattern"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-        <Spinner
-            android:id="@+id/strokePatternSpinner"
-            android:spinnerMode="dropdown"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
 
-    </LinearLayout>
+                <TextView
+                    android:text="@string/stroke_joint_type"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+                <Spinner
+                    android:id="@+id/strokeJointTypeSpinner"
+                    android:spinnerMode="dropdown"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
 
-    <CheckBox
-        android:id="@+id/toggleClickability"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="true"
-        android:onClick="toggleClickability"
-        android:text="@string/clickable" />
+                <TextView
+                    android:text="@string/stroke_pattern"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+                <Spinner
+                    android:id="@+id/strokePatternSpinner"
+                    android:spinnerMode="dropdown"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+            </LinearLayout>
+
+            <CheckBox
+                android:id="@+id/toggleClickability"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:onClick="toggleClickability"
+                android:text="@string/clickable" />
+        </LinearLayout>
+    </ScrollView>
 
     <fragment
         android:id="@+id/map"
         class="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/scrollView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/polyline_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/polyline_demo.xml
@@ -16,6 +16,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/polyline_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/polyline_demo.xml
@@ -14,106 +14,127 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TableLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/polyline_demo_label" />
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:stretchColumns="1">
+        app:layout_constraintTop_toBottomOf="@id/top_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/map">
 
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/hue" />
-            <SeekBar android:id="@+id/hueSeekBar" />
-        </TableRow>
-
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/alpha" />
-            <SeekBar android:id="@+id/alphaSeekBar" />
-        </TableRow>
-
-        <TableRow
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical">
-            <TextView android:text="@string/width" />
-            <SeekBar android:id="@+id/widthSeekBar" />
-        </TableRow>
-
-    </TableLayout>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <TextView
-            android:text="@string/start_cap"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
-        <Spinner
-            android:id="@+id/startCapSpinner"
-            android:spinnerMode="dropdown"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
-        <TextView
-            android:text="@string/end_cap"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-        <Spinner
-            android:id="@+id/endCapSpinner"
-            android:spinnerMode="dropdown"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-
-    </LinearLayout>
-
-    <LinearLayout
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
-        <TextView
-            android:text="@string/joint_type"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-        <Spinner
-            android:id="@+id/jointTypeSpinner"
-            android:spinnerMode="dropdown"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
 
-        <TextView
-            android:text="@string/pattern"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
-        <Spinner
-            android:id="@+id/patternSpinner"
-            android:spinnerMode="dropdown"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"/>
+            <TableLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:stretchColumns="1">
 
-    </LinearLayout>
+                <TableRow>
+                    <TextView android:text="@string/hue" />
+                    <SeekBar android:id="@+id/hueSeekBar" />
+                </TableRow>
 
-    <CheckBox
-        android:id="@+id/toggleClickability"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="true"
-        android:onClick="toggleClickability"
-        android:text="@string/clickable" />
+                <TableRow>
+                    <TextView android:text="@string/alpha" />
+                    <SeekBar android:id="@+id/alphaSeekBar" />
+                </TableRow>
+
+                <TableRow>
+                    <TextView android:text="@string/width" />
+                    <SeekBar android:id="@+id/widthSeekBar" />
+                </TableRow>
+            </TableLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:text="@string/start_cap"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+                <Spinner
+                    android:id="@+id/startCapSpinner"
+                    android:spinnerMode="dropdown"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+
+                <TextView
+                    android:text="@string/end_cap"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+                <Spinner
+                    android:id="@+id/endCapSpinner"
+                    android:spinnerMode="dropdown"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:text="@string/joint_type"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+                <Spinner
+                    android:id="@+id/jointTypeSpinner"
+                    android:spinnerMode="dropdown"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+
+                <TextView
+                    android:text="@string/pattern"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+                <Spinner
+                    android:id="@+id/patternSpinner"
+                    android:spinnerMode="dropdown"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"/>
+            </LinearLayout>
+
+            <CheckBox
+                android:id="@+id/toggleClickability"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:onClick="toggleClickability"
+                android:text="@string/clickable" />
+        </LinearLayout>
+    </ScrollView>
 
     <fragment
         android:id="@+id/map"
         class="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/scrollView"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/raw_mapview_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/raw_mapview_demo.xml
@@ -14,6 +14,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 --><!-- This can go anywhere in your layout. -->
+
 <com.google.android.gms.maps.MapView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/map"
     android:layout_width="match_parent"

--- a/ApiDemos/java/app/src/main/res/layout/save_state_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/save_state_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,21 +13,39 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <TextView
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/save_state_demo_label" />
+
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/instructions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/save_state_instructions" />
+        android:text="@string/save_state_instructions"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar" />
 
     <fragment
         android:id="@+id/map"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        class="com.example.mapdemo.SaveStateDemoActivity$SaveStateMapFragment" />
+        class="com.example.mapdemo.SaveStateDemoActivity$SaveStateMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/instructions" />
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/ApiDemos/java/app/src/main/res/layout/save_state_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/save_state_demo.xml
@@ -15,6 +15,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/snapshot_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/snapshot_demo.xml
@@ -21,9 +21,11 @@
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/topAppBar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/colorPrimary"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/snapshot_demo_label" />
 

--- a/ApiDemos/java/app/src/main/res/layout/snapshot_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/snapshot_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,54 +13,70 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/snapshot_demo_label" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@id/bottomContainer"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar">
 
         <fragment
             android:id="@+id/map"
+            class="com.google.android.gms.maps.SupportMapFragment"
             android:layout_width="match_parent"
-            android:layout_weight="1"
             android:layout_height="0dp"
-            class="com.google.android.gms.maps.SupportMapFragment" />
+            android:layout_weight="1" />
 
         <ImageView
             android:id="@+id/snapshot_holder"
             android:layout_width="match_parent"
-            android:layout_weight="1"
             android:layout_height="0dp"
+            android:layout_weight="1"
             android:contentDescription="@string/snapshot_holder_description" />
     </LinearLayout>
 
-    <CheckBox
+    <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/wait_for_map_load"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:checked="true"
-        android:text="@string/wait_for_map_load" />
+        android:text="@string/wait_for_map_load"
+        app:layout_constraintBottom_toTopOf="@id/bottomContainer" />
 
     <LinearLayout
+        android:id="@+id/bottomContainer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:onClick="onScreenshot"
             android:text="@string/snapshot_take_button" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:onClick="onClearScreenshot"
             android:text="@string/snapshot_clear_button" />
     </LinearLayout>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/snapshot_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/snapshot_demo.xml
@@ -15,6 +15,7 @@
 -->
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/split_street_view_panorama_and_map_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/split_street_view_panorama_and_map_demo.xml
@@ -14,7 +14,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/ApiDemos/java/app/src/main/res/layout/split_street_view_panorama_and_map_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/split_street_view_panorama_and_map_demo.xml
@@ -13,37 +13,40 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
---><!-- This can go anywhere in your layout. -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:map="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/map_container"
+-->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <LinearLayout
-        android:id="@+id/map_container2"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_weight="0.5"
-        android:orientation="vertical">
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/split_street_view_panorama_and_map_demo_label" />
 
-        <fragment
-            android:id="@+id/streetviewpanorama"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="0.5"
-            class="com.google.android.gms.maps.SupportStreetViewPanoramaFragment" />
+    <fragment
+        android:id="@+id/streetviewpanorama"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        class="com.google.android.gms.maps.SupportStreetViewPanoramaFragment"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.5" />
 
-        <fragment
-            android:id="@+id/map"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_weight="0.5"
-            class="com.google.android.gms.maps.SupportMapFragment"
-            map:cameraTargetLat="-33.87365"
-            map:cameraTargetLng="151.20689"
-            map:cameraZoom="15" />
-    </LinearLayout>
-</LinearLayout>
+    <fragment
+        android:id="@+id/map"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        app:layout_constraintTop_toBottomOf="@id/streetviewpanorama"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.5" />
 
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/street_view_panorama_basic_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/street_view_panorama_basic_demo.xml
@@ -14,7 +14,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 --><!-- This can go anywhere in your layout. -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    android:id="@+id/map_container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/ApiDemos/java/app/src/main/res/layout/street_view_panorama_events_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/street_view_panorama_events_demo.xml
@@ -13,7 +13,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/map_container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">

--- a/ApiDemos/java/app/src/main/res/layout/street_view_panorama_events_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/street_view_panorama_events_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,44 +13,59 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <fragment
+
         android:id="@+id/streetviewpanorama"
+        class="com.google.android.gms.maps.SupportStreetViewPanoramaFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        class="com.google.android.gms.maps.SupportStreetViewPanoramaFragment" />
+        app:layout_constraintTop_toBottomOf="@id/topAppBar" />
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/street_view_panorama_events_demo_label" />
+
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar">
 
         <TextView
             android:id="@+id/change_pano"
-            android:text="@string/navigate_to_another_panorama"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:text="@string/navigate_to_another_panorama" />
 
         <TextView
             android:id="@+id/change_camera"
-            android:text="@string/pan_camera"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:text="@string/pan_camera" />
 
         <TextView
             android:id="@+id/click_pano"
-            android:text="@string/tap_screen"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:text="@string/tap_screen" />
 
         <TextView
             android:id="@+id/long_click_pano"
-            android:text="@string/long_press_screen"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:text="@string/long_press_screen" />
     </LinearLayout>
-</FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/street_view_panorama_navigation_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/street_view_panorama_navigation_demo.xml
@@ -13,7 +13,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    android:id="@+id/map_container"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/ApiDemos/java/app/src/main/res/layout/street_view_panorama_navigation_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/street_view_panorama_navigation_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,28 +13,44 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/street_view_panorama_navigation_demo_label" />
+
+    <LinearLayout
+        android:id="@+id/first_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:baselineAligned="false"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar">
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:orientation="vertical">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/get_position"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="onRequestPosition"
                 android:text="@string/request_position" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/move_position"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -46,57 +61,57 @@
         <RelativeLayout
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:gravity="center_horizontal"
-            android:layout_weight="1">
+            android:layout_weight="1"
+            android:gravity="center_horizontal">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/pan_left"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:minWidth="48dp"
-                android:onClick="onPanLeft"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
+                android:minWidth="48dp"
+                android:onClick="onPanLeft"
                 android:text="@string/left_arrow" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/pan_up"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_toEndOf="@id/pan_left"
                 android:minWidth="48dp"
                 android:onClick="onPanUp"
-                android:layout_alignParentTop="true"
-                android:layout_toRightOf="@id/pan_left"
                 android:text="@string/up_arrow" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/pan_down"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_below="@id/pan_up"
+                android:layout_toEndOf="@id/pan_left"
                 android:minWidth="48dp"
                 android:onClick="onPanDown"
-                android:layout_below="@id/pan_up"
-                android:layout_toRightOf="@id/pan_left"
                 android:text="@string/down_arrow" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/pan_right"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_centerVertical="true"
+                android:layout_toEndOf="@id/pan_down"
                 android:minWidth="48dp"
                 android:onClick="onPanRight"
-                android:layout_centerVertical="true"
-                android:layout_toRightOf="@id/pan_down"
                 android:text="@string/right_arrow" />
         </RelativeLayout>
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:layout_gravity="right"
+            android:layout_gravity="end"
             android:orientation="vertical">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/zoom_in"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -104,7 +119,7 @@
                 android:onClick="onZoomIn"
                 android:text="@string/zoom_in" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/zoom_out"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -115,8 +130,12 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/second_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/first_container">
 
         <TextView
             android:layout_width="wrap_content"
@@ -129,54 +148,62 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:progress="1000"
-            android:max="5000" />
+            android:max="5000"
+            android:progress="1000" />
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/third_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/second_container">
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/sydney"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
-            android:onClick="onGoToSydney"
             android:layout_weight="1"
+            android:onClick="onGoToSydney"
             android:text="@string/go_to_sydney" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/sanfran"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
-            android:onClick="onGoToSanFran"
             android:layout_weight="1"
+            android:onClick="onGoToSanFran"
             android:text="@string/go_to_san_fran" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/santorini"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
-            android:onClick="onGoToSantorini"
             android:layout_weight="1"
+            android:onClick="onGoToSantorini"
             android:text="@string/go_to_santorini" />
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/invalid"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_gravity="center_vertical"
-            android:onClick="onGoToInvalid"
             android:layout_weight="1"
+            android:onClick="onGoToInvalid"
             android:text="@string/go_to_invalid" />
     </LinearLayout>
 
     <fragment
         android:id="@+id/streetviewpanorama"
+        class="com.google.android.gms.maps.SupportStreetViewPanoramaFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        class="com.google.android.gms.maps.SupportStreetViewPanoramaFragment" />
-</LinearLayout>
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/third_container" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/street_view_panorama_options_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/street_view_panorama_options_demo.xml
@@ -14,11 +14,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 --><!-- This can go anywhere in your layout. -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    <fragment
         android:id="@+id/streetviewpanorama"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/ApiDemos/java/app/src/main/res/layout/styled_map_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/styled_map_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2023 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +14,26 @@
  limitations under the License.
 -->
 
-<fragment
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/map"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    class="com.google.android.gms.maps.SupportMapFragment" />
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/styled_map_demo_label" />
+
+
+    <fragment
+        android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/java/app/src/main/res/layout/styled_map_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/styled_map_demo.xml
@@ -15,7 +15,8 @@
  limitations under the License.
 -->
 
-<fragment xmlns:android="http://schemas.android.com/apk/res/android"
+<fragment
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/map"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/ApiDemos/java/app/src/main/res/layout/tags_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/tags_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +14,20 @@
  limitations under the License.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-      android:layout_width="match_parent"
-      android:layout_height="match_parent"
-      android:orientation="vertical">
+    android:id="@+id/map_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <TextView
         android:id="@+id/tag_text"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
+
     <fragment
         android:id="@+id/map"
+        class="com.google.android.gms.maps.SupportMapFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        class="com.google.android.gms.maps.SupportMapFragment"/>
+        android:layout_height="match_parent" />
 
 </LinearLayout>

--- a/ApiDemos/java/app/src/main/res/layout/visible_region_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/visible_region_demo.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +14,7 @@
  limitations under the License.
 --><!-- This can go anywhere in your layout (see other demos for some examples). -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/map_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -24,62 +24,62 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+        <fragment
             android:id="@+id/map"
+            class="com.google.android.gms.maps.SupportMapFragment"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            class="com.google.android.gms.maps.SupportMapFragment" />
+            android:layout_height="match_parent" />
 
         <LinearLayout
+            android:layout_width="150px"
+            android:layout_height="match_parent"
             android:layout_gravity="bottom|right"
             android:background="#A000"
             android:orientation="vertical"
-            android:padding="5dp"
-            android:layout_height="match_parent"
-            android:layout_width="150px">
+            android:padding="5dp">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_normal_button"
-                android:padding="8dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="setNoPadding"
+                android:padding="8dp"
                 android:text="@string/vr_normal_button" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_more_padded_button"
-                android:padding="8dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="setMorePadding"
+                android:padding="8dp"
                 android:text="@string/vr_more_padded_button" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_soh_button"
-                android:padding="8dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="moveToOperaHouse"
+                android:padding="8dp"
                 android:text="@string/vr_soh_button" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_sfo_button"
-                android:padding="8dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="moveToSFO"
+                android:padding="8dp"
                 android:text="@string/vr_sfo_button" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_aus_button"
-                android:padding="8dp"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:onClick="moveToAUS"
+                android:padding="8dp"
                 android:text="@string/vr_aus_button" />
         </LinearLayout>
     </RelativeLayout>

--- a/ApiDemos/java/app/src/main/res/layout/visible_region_demo.xml
+++ b/ApiDemos/java/app/src/main/res/layout/visible_region_demo.xml
@@ -42,7 +42,7 @@
             android:layout_height="match_parent"
             android:layout_width="150px">
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_normal_button"
                 android:padding="8dp"
                 android:layout_width="wrap_content"
@@ -50,7 +50,7 @@
                 android:onClick="setNoPadding"
                 android:text="@string/vr_normal_button" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_more_padded_button"
                 android:padding="8dp"
                 android:layout_width="wrap_content"
@@ -58,7 +58,7 @@
                 android:onClick="setMorePadding"
                 android:text="@string/vr_more_padded_button" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_soh_button"
                 android:padding="8dp"
                 android:layout_width="wrap_content"
@@ -66,7 +66,7 @@
                 android:onClick="moveToOperaHouse"
                 android:text="@string/vr_soh_button" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_sfo_button"
                 android:padding="8dp"
                 android:layout_width="wrap_content"
@@ -74,7 +74,7 @@
                 android:onClick="moveToSFO"
                 android:text="@string/vr_sfo_button" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/vr_aus_button"
                 android:padding="8dp"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
This PR updates the Samples to incorporate Material Design, including a Material Bar and Material components, and migrates layouts to `ConstraintLayout` where possible. It also introduces a base activity that enables Edge-to-Edge mode and provides a function to apply insets.  

Activities and layouts have been adapted, with insets applied at the top-level layout. Note that some layouts may not use `ConstraintLayout`, as they are designed to showcase a single Fragment or View.  

In future PRs, we plan to update the Kotlin samples to support Edge-to-Edge, insets, and Material Design using the same layouts. We also aim to merge the Kotlin and Java samples into a single project with two modules. However, due to the size of this PR, these changes will be addressed separately.
