### PR TITLE
chore: fixed paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,14 +15,14 @@
 version: 2
 updates:
 - package-ecosystem: gradle
-  directory: "/./ApiDemos/java"
+  directory: "/./ApiDemos/project/java-app"
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10
   commit-message:
     prefix: chore(deps)
 - package-ecosystem: gradle
-  directory: "/./ApiDemos/kotlin"
+  directory: "/./ApiDemos/project/kotlin-app"
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,13 @@ jobs:
     - name: Build APKs
       run: |
         echo "Generating ApiDemos (Java) APKs"
-        cd $GITHUB_WORKSPACE/ApiDemos/java
+        cd $GITHUB_WORKSPACE/ApiDemos/project/
         ./gradlew assemble
-        cp ./app/build/outputs/apk/debug/app-debug.apk $GITHUB_WORKSPACE/ApiDemos-java-debug.apk
+        cp ./java-app/build/outputs/apk/debug/java-app-debug.apk $GITHUB_WORKSPACE/ApiDemos-java-debug.apk
 
         echo "Generating Kotlin (Kotlin) APKs"
-        cd $GITHUB_WORKSPACE/ApiDemos/kotlin
         ./gradlew assemble
-        cp ./app/build/outputs/apk/debug/app-debug.apk $GITHUB_WORKSPACE/ApiDemos-kotlin-debug.apk
+        cp ./kotlin-app/build/outputs/apk/debug/kotlin-app-debug.apk $GITHUB_WORKSPACE/ApiDemos-kotlin-debug.apk
 
     - uses: actions/setup-node@v2
       with:

--- a/.releaserc
+++ b/.releaserc
@@ -6,14 +6,14 @@ plugins:
   - - "@google/semantic-release-replace-plugin"
     - replacements:
         - files:
-            - "./ApiDemos/java/app/build.gradle.kts"
-            - "./ApiDemos/kotlin/app/build.gradle.kts"
+            - "./ApiDemos/project/java-app/build.gradle.kts"
+            - "./ApiDemos/project/kotlin-app/build.gradle.kts"
           from: "versionName = \".*\""
           to: "versionName = \"${nextRelease.version}\""
   - - "@semantic-release/git"
     - assets:
-        - "./ApiDemos/java/app/build.gradle.kts"
-        - "./ApiDemos/kotlin/app/build.gradle.kts"
+        - "./ApiDemos/project/java-app/build.gradle.kts"
+        - "./ApiDemos/project/kotlin-app/build.gradle.kts"
   - - "@semantic-release/github"
     - assets:
         - "./ApiDemos-java-debug.apk"

--- a/ApiDemos/project/README.md
+++ b/ApiDemos/project/README.md
@@ -28,7 +28,7 @@ This sample use the Gradle build system.
 First download the samples by cloning this repository or downloading an archived snapshot. (See the options at the top of the page.)
 
 In Android Studio, use "Open an existing Android Studio project".
-Next select the `ApiDemos/java/` directory that you downloaded from this repository.
+Next select the `ApiDemos/project/` directory that you downloaded from this repository.
 If prompted for a gradle configuration accept the default settings. 
 
 Alternatively use the `gradlew build` command to build the project directly.

--- a/ApiDemos/project/common-ui/build.gradle.kts
+++ b/ApiDemos/project/common-ui/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation(libs.coreKtx)
     implementation(libs.appcompat)
     implementation(libs.material)
+    implementation(libs.playServicesMaps)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidxJunit)
     androidTestImplementation(libs.espressoCore)


### PR DESCRIPTION
The following [PR introduced ](https://github.com/googlemaps-samples/android-samples/pull/2026)a unified project for the Kotlin and Java samples. This PR fixes some paths to generate the samples, since now the location has changed.