### PR TITLE
chore: increased libraries, replaced deprecated methods

### DIFF
--- a/snippets/app-compose/build.gradle.kts
+++ b/snippets/app-compose/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     // [END_EXCLUDE]
 
     // Android Maps Compose composables for the Maps SDK for Android
-    implementation("com.google.maps.android:maps-compose:6.4.1")
+    implementation("com.google.maps.android:maps-compose:6.7.1")
 }
 // [END maps_android_compose_dependency]
 

--- a/snippets/app-compose/src/main/java/com/example/app_compose/MapsCompose.kt
+++ b/snippets/app-compose/src/main/java/com/example/app_compose/MapsCompose.kt
@@ -33,13 +33,13 @@ import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
-import com.google.maps.android.compose.rememberMarkerState
+import com.google.maps.android.compose.rememberUpdatedMarkerState
 
 @Composable
 fun AddAMap() {
   // [START maps_android_compose_add_a_map]
   val singapore = LatLng(1.35, 103.87)
-  val singaporeMarkerState = rememberMarkerState(position = singapore)
+  val singaporeMarkerState = rememberUpdatedMarkerState(position = singapore)
   val cameraPositionState = rememberCameraPositionState {
     position = CameraPosition.fromLatLngZoom(singapore, 10f)
   }

--- a/snippets/app-rx/build.gradle.kts
+++ b/snippets/app-rx/build.gradle.kts
@@ -66,8 +66,8 @@ dependencies {
     // It is recommended to also include the latest Maps SDK, Places SDK and RxJava so you
     // have the latest features and bug fixes.
     implementation("com.google.android.gms:play-services-maps:19.2.0")
-    implementation("com.google.android.libraries.places:places:4.3.1")
-    implementation("io.reactivex.rxjava3:rxjava:3.1.8")
+    implementation("com.google.android.libraries.places:places:4.4.1")
+    implementation("io.reactivex.rxjava3:rxjava:3.1.11")
 
     // [START_EXCLUDE silent]
     implementation(libs.appcompat)

--- a/snippets/app-utils/build.gradle.kts
+++ b/snippets/app-utils/build.gradle.kts
@@ -70,7 +70,7 @@ dependencies {
     // Utility Library for Maps SDK for Android
     // You do not need to add a separate dependency for the Maps SDK for Android
     // since this library builds in the compatible version of the Maps SDK.
-    implementation("com.google.maps.android:android-maps-utils:3.12.0")
+    implementation("com.google.maps.android:android-maps-utils:3.14.0")
 }
 // [END maps_android_utils_install_snippet]
 

--- a/snippets/app/build.gradle.kts
+++ b/snippets/app/build.gradle.kts
@@ -81,7 +81,7 @@ dependencies {
     // [END_EXCLUDE]
 
     // Maps SDK for Android
-    implementation("com.google.android.gms:play-services-maps:19.0.0")
+    implementation("com.google.android.gms:play-services-maps:19.2.0")
 }
 // [END maps_android_play_services_maps_dependency]
 

--- a/snippets/gradle/libs.versions.toml
+++ b/snippets/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-espressoCore = "3.6.1"
+espressoCore = "3.7.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
+junitVersion = "1.3.0"
 kotlin = "2.2.0"
 coreKtx = "1.16.0"
 appCompat = "1.7.1"
@@ -10,13 +10,13 @@ composeMaterial = "1.8.3"
 mapsKtx = "5.2.0"
 material = "1.12.0"
 constraintLayout = "2.2.1"
-navigation = "2.9.0"
+navigation = "2.9.3"
 rxlifecycleAndroidLifecycleKotlin = "4.0.2"
 volley = "1.2.1"
-lifecycleRuntime = "2.9.1"
-places = "4.3.1"
+lifecycleRuntime = "2.9.2"
+places = "4.4.1"
 secretsGradlePlugin = "2.0.1"
-agp = "8.10.1"
+agp = "8.12.0"
 
 [libraries]
 espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }

--- a/snippets/gradle/wrapper/gradle-wrapper.properties
+++ b/snippets/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Jul 10 22:14:33 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The following PR updates the dependencies on the snippets. rememberMarkerState was [deprecated](https://github.com/googlemaps/android-maps-compose/pull/730) in favour of rememberUpdatedMarkerState, and this is also reflected now in the snippets.