### PR TITLE
chore: update maps dependencies to stable releases and make mavenLocal opt-in

### DIFF
--- a/ApiDemos/project/build.gradle.kts
+++ b/ApiDemos/project/build.gradle.kts
@@ -33,7 +33,10 @@ buildscript {
 
 allprojects {
     repositories {
-        mavenLocal()
+        if (providers.gradleProperty("useMavenLocal").orNull == "true" ||
+            providers.environmentVariable("USE_MAVEN_LOCAL").orNull == "true") {
+            mavenLocal()
+        }
         google()
         mavenCentral()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,9 +36,9 @@ material3 = "1.4.0"
 materialIconsExtended = "1.7.8"
 
 # Google Maps & Places
-mapsCompose = "8.4.0"
-mapsKtx = "6.3.0"
-mapsUtils = "5.1.1"
+mapsCompose = "8.5.0"
+mapsKtx = "6.4.1"
+mapsUtils = "5.2.0"
 places = "5.3.0"
 playServicesLocation = "21.4.0"
 playServicesMaps = "20.0.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
+        if (providers.gradleProperty("useMavenLocal").orNull == "true" ||
+            providers.environmentVariable("USE_MAVEN_LOCAL").orNull == "true") {
+            mavenLocal()
+        }
         google()
         mavenCentral()
     }

--- a/snippets/app-utils-ktx/build.gradle.kts
+++ b/snippets/app-utils-ktx/build.gradle.kts
@@ -25,7 +25,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.app_utils_ktx"
-        minSdk = 23
+        minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 1
         versionName = libs.versions.versionName.get()


### PR DESCRIPTION
Updates Google Maps Platform dependencies to latest stable releases (no release candidates) and improves build reproducibility:
- `maps-compose`: 8.4.0 -> 8.5.0
- `maps-ktx`: 6.3.0 -> 6.4.1
- `android-maps-utils`: 5.1.1 -> 5.2.0
- Makes `mavenLocal()` opt-in via `useMavenLocal=true` or `USE_MAVEN_LOCAL=true`
- Uses version catalog `minSdk` in `snippets/app-utils-ktx`