### PR TITLE
fix(WearOS): add safe ambient mode initialization and update copyright headers

### DIFF
--- a/WearOS/Wearable/build.gradle.kts
+++ b/WearOS/Wearable/build.gradle.kts
@@ -45,8 +45,15 @@ android {
         sarifOutput = layout.buildDirectory.file("reports/lint-results-debug.sarif").get().asFile
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     kotlin {
-        jvmToolchain(21)
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
     }
 }
 
@@ -90,11 +97,11 @@ dependencies {
     //    compileOnly("com.google.android.wearable:wearable:2.9.0")
     //    implementation("com.google.android.support:wearable:2.9.0")
     //    implementation("com.google.android.gms:play-services-maps:20.0.0")
-    //    implementation("androidx.wear:wear:1.3.0")
-    //    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    //    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    //    implementation("androidx.wear:wear:1.4.0")
+    //    androidTestImplementation("androidx.test.ext:junit:1.3.0")
+    //    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
     //    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
-    //    androidTestImplementation("com.google.truth:truth:1.4.2")
+    //    androidTestImplementation("com.google.truth:truth:1.4.5")
     //    androidTestImplementation("junit:junit:4.13.2")
 }
 // [END maps_wear_os_dependencies]

--- a/WearOS/Wearable/src/main/java/com/example/wearosmap/AmbientActivity.java
+++ b/WearOS/Wearable/src/main/java/com/example/wearosmap/AmbientActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc. All Rights Reserved.
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,8 +48,12 @@ public class AmbientActivity extends AppCompatActivity implements
         // Enable ambient support, so the map remains visible in simplified, low-color display
         // when the user is no longer actively using the app but the app is still visible on the
         // watch face.
-        AmbientModeSupport.AmbientController controller = AmbientModeSupport.attach(this);
-        Log.d(AmbientActivity.class.getSimpleName(), "Is ambient enabled: " + controller.isAmbient());
+        try {
+            AmbientModeSupport.AmbientController controller = AmbientModeSupport.attach(this);
+            Log.d(AmbientActivity.class.getSimpleName(), "Is ambient enabled: " + controller.isAmbient());
+        } catch (Exception e) {
+            Log.w(AmbientActivity.class.getSimpleName(), "Ambient mode unavailable on this device: " + e.getMessage());
+        }
 
         // Obtain the MapFragment and set the async listener to be notified when the map is ready.
         mapFragment = (SupportMapFragment) getSupportFragmentManager()

--- a/WearOS/Wearable/src/main/java/com/example/wearosmap/MainActivity.java
+++ b/WearOS/Wearable/src/main/java/com/example/wearosmap/MainActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc. All Rights Reserved.
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,9 +54,13 @@ public class MainActivity extends AppCompatActivity implements OnMapReadyCallbac
         // when the user is no longer actively using the app but the app is still visible on the
         // watch face.
         // [START maps_wear_os_ambient_mode_support]
-        AmbientModeSupport.AmbientController controller = AmbientModeSupport.attach(this);
+        try {
+            AmbientModeSupport.AmbientController controller = AmbientModeSupport.attach(this);
+            Log.d(MainActivity.class.getSimpleName(), "Is ambient enabled: " + controller.isAmbient());
+        } catch (Exception e) {
+            Log.w(MainActivity.class.getSimpleName(), "Ambient mode unavailable on this device: " + e.getMessage());
+        }
         // [END maps_wear_os_ambient_mode_support]
-        Log.d(MainActivity.class.getSimpleName(), "Is ambient enabled: " + controller.isAmbient());
 
         // Retrieve the containers for the root of the layout and the map. Margins will need to be
         // set on them to account for the system window insets.

--- a/WearOS/Wearable/src/main/kotlin/com/example/wearosmap/kt/AmbientActivity.kt
+++ b/WearOS/Wearable/src/main/kotlin/com/example/wearosmap/kt/AmbientActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc. All Rights Reserved.
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,12 @@ class AmbientActivity : AppCompatActivity(), AmbientModeSupport.AmbientCallbackP
         // Enable ambient support, so the map remains visible in simplified, low-color display
         // when the user is no longer actively using the app but the app is still visible on the
         // watch face.
-        val controller = AmbientModeSupport.attach(this)
-        Log.d(AmbientActivity::class.java.simpleName, "Is ambient enabled: " + controller.isAmbient)
+        try {
+            val controller = AmbientModeSupport.attach(this)
+            Log.d(AmbientActivity::class.java.simpleName, "Is ambient enabled: " + controller.isAmbient)
+        } catch (e: Exception) {
+            Log.w(AmbientActivity::class.java.simpleName, "Ambient mode unavailable on this device: ${e.message}")
+        }
 
         // Obtain the MapFragment and set the async listener to be notified when the map is ready.
         mapFragment = supportFragmentManager

--- a/WearOS/Wearable/src/main/kotlin/com/example/wearosmap/kt/MainActivity.kt
+++ b/WearOS/Wearable/src/main/kotlin/com/example/wearosmap/kt/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 Google Inc. All Rights Reserved.
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,9 +49,13 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback,
         // when the user is no longer actively using the app but the app is still visible on the
         // watch face.
         // [START maps_wear_os_ambient_mode_support]
-        val controller = AmbientModeSupport.attach(this)
+        try {
+            val controller = AmbientModeSupport.attach(this)
+            Log.d(MainActivity::class.java.simpleName, "Is ambient enabled: " + controller.isAmbient)
+        } catch (e: Exception) {
+            Log.w(MainActivity::class.java.simpleName, "Ambient mode unavailable on this device: ${e.message}")
+        }
         // [END maps_wear_os_ambient_mode_support]
-        Log.d(MainActivity::class.java.simpleName, "Is ambient enabled: " + controller.isAmbient)
 
         // Retrieve the containers for the root of the layout and the map. Margins will need to be
         // set on them to account for the system window insets.


### PR DESCRIPTION
### Summary

- **Ambient Mode Hardening**: Safely wrap `AmbientModeSupport.attach(this)` in a try/catch across Kotlin and Java activities (`MainActivity` and `AmbientActivity`) to gracefully handle runtime environments that lack the Wear OS shared library.
- **Toolchain & Metadata**: Update `WearOS/Wearable/build.gradle.kts` and standard 2026 Google LLC copyright headers across Wear OS source files.

Part of stack: #2390