### PR TITLE
fix(ApiDemos): improve window insets handling, save state layout, and demo reliability

### DIFF
--- a/ApiDemos/project/common-ui/src/main/res/layout/camera_clamping_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/camera_clamping_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -50,31 +50,30 @@
         map:latLngBoundsSouthWestLongitude="-122.1" />
 
     <LinearLayout
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         android:id="@+id/container"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:padding="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/top_bar">
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:paddingHorizontal="4dp"
             android:orientation="horizontal">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/clamp_min_zoom"
-                android:layout_width="wrap_content"
+            <TextView
+                android:id="@+id/zoom_label"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:text="@string/clamp_min_zoom" />
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/clamp_max_zoom"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/clamp_max_zoom" />
+                android:layout_weight="1"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:text="@string/initial_zoom_limits" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_zoom_reset"
@@ -83,43 +82,63 @@
                 android:text="@string/clamp_zoom_reset" />
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
+        <com.google.android.material.slider.RangeSlider
+            android:id="@+id/zoom_range_slider"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:valueFrom="2.0"
+            android:valueTo="21.0"
+            android:stepSize="0.5"
+            app:values="@array/initial_zoom_range" />
+
+        <com.google.android.material.button.MaterialButtonToggleGroup
+            android:id="@+id/latlng_clamp_toggle_group"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:singleSelection="true"
+            app:selectionRequired="false">
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_latlng_adelaide"
-                android:layout_width="wrap_content"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_weight="0.5"
+                android:layout_weight="1"
                 android:text="@string/clamp_latlng_adelaide" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_latlng_pacific"
-                android:layout_width="wrap_content"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_weight="0.5"
+                android:layout_weight="1"
                 android:text="@string/clamp_latlng_pacific" />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/clamp_latlng_reset"
-                android:layout_width="wrap_content"
+                style="?attr/materialButtonOutlinedStyle"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:text="@string/clamp_latlng_reset" />
-        </LinearLayout>
+        </com.google.android.material.button.MaterialButtonToggleGroup>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
+        <TextView
+            android:id="@+id/clamp_status_text"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:paddingHorizontal="4dp"
+            android:paddingTop="4dp"
+            android:textAppearance="?attr/textAppearanceBodyMedium"
+            android:text="@string/latlng_clamp_status_none" />
 
-            <TextView
-                android:id="@+id/camera_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/move_the_camera" />
-        </LinearLayout>
+        <TextView
+            android:id="@+id/camera_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="4dp"
+            android:paddingTop="2dp"
+            android:text="@string/move_the_camera" />
     </LinearLayout>
 
   </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/project/common-ui/src/main/res/layout/camera_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/camera_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:title="@string/background_color_customization_demo_label"
+        app:title="@string/camera_demo_label"
         app:titleTextColor="?attr/colorOnPrimary" />
 
     <androidx.fragment.app.FragmentContainerView
@@ -40,7 +40,7 @@
         android:id="@+id/first_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         android:baselineAligned="false"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -160,7 +160,7 @@
         android:id="@+id/second_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/first_container">
@@ -183,7 +183,7 @@
         android:id="@+id/third_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/second_container">

--- a/ApiDemos/project/common-ui/src/main/res/layout/ground_overlay_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/ground_overlay_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         android:padding="5dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/ApiDemos/project/common-ui/src/main/res/layout/layers_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/layers_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -43,38 +43,40 @@
         android:id="@+id/checkbox_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:minWidth="160dp"
+        android:background="?attr/colorSurface"
         android:orientation="vertical"
-        android:padding="6dp"
+        android:padding="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/map">
 
         <Spinner
             android:id="@+id/layers_spinner"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:minHeight="48dp" />
 
-        <CheckBox
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/traffic"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/traffic" />
 
-        <CheckBox
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/my_location"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="false"
             android:text="@string/my_location" />
 
-        <CheckBox
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/buildings"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="true"
             android:text="@string/buildings" />
 
-        <CheckBox
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/indoor"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/ApiDemos/project/common-ui/src/main/res/layout/marker_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/marker_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/map_container"
     android:layout_width="match_parent"
@@ -27,12 +27,59 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:title="@string/marker_demo_label" />
+        app:title="@string/marker_demo_label"
+        app:titleTextColor="?attr/colorOnPrimary" />
 
+    <LinearLayout
+        android:id="@+id/top_controls"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:orientation="vertical"
+        android:padding="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar">
+
+        <TextView
+            android:id="@+id/top_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lines="2"
+            android:text="@string/drag_melbourne" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <CheckBox
+                android:id="@+id/flat"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/flat" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:text="@string/rotation" />
+
+            <SeekBar
+                android:id="@+id/rotationSeekBar"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+    </LinearLayout>
 
     <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:id="@+id/map_frame"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_controls">
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/map"
@@ -44,25 +91,28 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|start"
-            android:background="@color/white"
+            android:background="?attr/colorSurface"
             android:orientation="vertical"
-            android:padding="5dp">
+            android:padding="8dp">
 
             <LinearLayout
+                style="?android:attr/buttonBarStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
-        <Button
-            android:id="@+id/clear_map"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/clear_map" />
+                <Button
+                    android:id="@+id/clear_map"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/clear_map" />
 
-        <Button
-            android:id="@+id/reset_map"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/reset_map" />
+                <Button
+                    android:id="@+id/reset_map"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/reset_map" />
             </LinearLayout>
 
             <RadioGroup
@@ -92,41 +142,4 @@
         </LinearLayout>
     </FrameLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="?attr/actionBarSize"
-        android:background="@color/white"
-        android:orientation="vertical">
-
-        <TextView
-            android:id="@+id/top_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:lines="2"
-            android:text="@string/drag_melbourne" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-        <CheckBox
-            android:id="@+id/flat"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/flat" />
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="8dp"
-                android:text="@string/rotation" />
-
-            <SeekBar
-                android:id="@+id/rotationSeekBar"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content" />
-        </LinearLayout>
-    </LinearLayout>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/project/common-ui/src/main/res/layout/street_view_panorama_events_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/street_view_panorama_events_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         android:orientation="vertical"
         app:layout_constraintTop_toBottomOf="@id/topAppBar">
 

--- a/ApiDemos/project/common-ui/src/main/res/layout/street_view_panorama_options_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/street_view_panorama_options_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
         android:layout_alignParentLeft="true"
         android:layout_alignTop="@+id/streetviewpanorama"
         android:padding="6dp"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         android:orientation="vertical">
 
         <CheckBox

--- a/ApiDemos/project/common-ui/src/main/res/layout/tile_overlay_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/tile_overlay_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentRight="true"
-        android:background="@color/white"
+        android:background="?attr/colorSurface"
         android:orientation="vertical">
 
         <CheckBox

--- a/ApiDemos/project/common-ui/src/main/res/layout/ui_settings_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/ui_settings_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@
             android:layout_height="wrap_content"
             android:paddingRight="5dp"
             android:paddingEnd="5dp"
-            android:background="@color/white"
+            android:background="?attr/colorSurface"
             android:orientation="vertical">
 
             <CheckBox

--- a/ApiDemos/project/common-ui/src/main/res/values/arrays.xml
+++ b/ApiDemos/project/common-ui/src/main/res/values/arrays.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<resources>
+    <array name="initial_zoom_range">
+        <item>2.0</item>
+        <item>21.0</item>
+    </array>
+</resources>

--- a/ApiDemos/project/common-ui/src/main/res/values/strings.xml
+++ b/ApiDemos/project/common-ui/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="demo_title">Maps SDK for Android Demos (Java)</string>
     <string name="demo_title_java">Maps SDK for Android Demos (Java)</string>
     <string name="demo_title_kotlin">Maps SDK for Android Demos (Kotlin)</string>
@@ -32,12 +32,18 @@
 
     <string name="camera_clamping_demo_description">Demonstrates how to use Camera Clamping.</string>
     <string name="camera_clamping_demo_label">Camera Clamping Demo</string>
-    <string name="clamp_latlng_adelaide">Clamp to Adelaide</string>
-    <string name="clamp_latlng_pacific">Clamp to Pacific</string>
-    <string name="clamp_latlng_reset">Reset LatLng Bounds</string>
+    <string name="clamp_latlng_adelaide">Adelaide</string>
+    <string name="clamp_latlng_pacific">Pacific</string>
+    <string name="clamp_latlng_reset">Reset</string>
+    <string name="latlng_clamp_status_none">Bounds: None</string>
+    <string name="latlng_clamp_status_adelaide">Bounds: Adelaide</string>
+    <string name="latlng_clamp_status_pacific">Bounds: Pacific</string>
+    <string name="camera_position_format">Position: (%1$.6f, %2$.6f)\nzoom=%3$.1f, tilt=%4$.1f\u00b0, bearing=%5$.1f\u00b0</string>
     <string name="clamp_min_zoom">MinZoom++</string>
-    <string name="clamp_max_zoom">MaxZoom--</string>
-    <string name="clamp_zoom_reset">Reset Zoom Bounds</string>
+    <string name="clamp_max_zoom" tools:ignore="TypographyDashes">MaxZoom--</string>
+    <string name="clamp_zoom_reset">Reset Zoom</string>
+    <string name="zoom_bounds_label">Zoom Limits: %1$.1f – %2$.1f</string>
+    <string name="initial_zoom_limits">Zoom Limits: 2.0 – 21.0</string>
 
     <string name="clear_map">Clear</string>
     <string name="clickable">Clickable</string>
@@ -51,6 +57,9 @@
     <string name="duration">Custom Duration</string>
     <string name="events_demo_label">Events</string>
     <string name="events_demo_description">Demonstrates event handling.</string>
+    <string name="events_tapped_format">Tapped: (%1$s, %2$s)</string>
+    <string name="events_long_pressed_format">Long pressed: (%1$s, %2$s)</string>
+    <string name="events_camera_position_format">Position: (%1$s, %2$s)\nzoom=%3$s, tilt=%4$s\u00b0, bearing=%5$s\u00b0</string>
     <string name="fade_in">Fade In Tiles</string>
     <string name="fill_alpha">Fill Alpha</string>
     <string name="fill_hue">Fill Hue</string>
@@ -121,6 +130,9 @@
     <string name="snapshot_demo_description">Demonstrates how to take a snapshot of the map.</string>
     <string name="snapshot_holder_description">Area for the map snapshot.</string>
     <string name="snapshot_take_button">Take snapshot</string>
+    <string name="snapshot_live_map_label">Live Map</string>
+    <string name="snapshot_preview_label">Captured Snapshot</string>
+    <string name="snapshot_placeholder_text">Tap \"Take snapshot\" to capture the map</string>
     <string name="stop_animation">\u25A0</string>
     <string name="stroke_alpha">Stroke Alpha</string>
     <string name="stroke_hue">Stroke Hue</string>
@@ -199,10 +211,19 @@
     <string name="request_position">Position</string>
     <string name="split_street_view_panorama_and_map_demo_description">Demonstrates how to show a Street View panorama and map.</string>
     <string name="split_street_view_panorama_and_map_demo_label">Street View Panorama and Map</string>
+    <string name="split_street_view_instructions">Long-press &amp; drag Pegman on the map to jump Street View. Tap arrows in Street View to walk.</string>
+    <string name="moved_pegman_to_location">Moved Pegman to your location</string>
+    <string name="getting_location">Finding your current location\u2026</string>
+    <string name="waiting_for_location">Location unavailable. Please check device location settings.</string>
+    <string name="location_permission_required_toast">Location permission is required to find your location. Please grant it in app settings.</string>
     <string name="street_view_panorama_basic_demo_description">Standard Street View Panorama using a Fragment.</string>
     <string name="street_view_panorama_basic_demo_label">Street View Panorama</string>
     <string name="street_view_panorama_events_demo_description">Standard Street View Panorama with event handling.</string>
     <string name="street_view_panorama_events_demo_label">Street View Panorama events</string>
+    <string name="pano_change_times">Times panorama changed=%1$d</string>
+    <string name="pano_camera_change_times">Times camera changed=%1$d</string>
+    <string name="pano_click_times">Times clicked=%1$d : %2$s</string>
+    <string name="pano_long_click_times">Times long clicked=%1$d : %2$s</string>
     <string name="street_view_panorama_navigation_demo_description">Street View Panorama with programmatic navigation.</string>
     <string name="street_view_panorama_navigation_demo_label">Street View Panorama navigation</string>
     <string name="street_view_panorama_options_demo_description">Street View Panorama with toggles for options.</string>
@@ -217,6 +238,7 @@
     <!-- Advanced Markers Demo -->
     <string name="advanced_markers_demo_label">Advanced Markers</string>
     <string name="advanced_markers_demo_details">Showcases the usage of Advanced Markers.</string>
+    <string name="advanced_marker_hello">Hello!</string>
     <string name="map_id">DEMO_MAP_ID</string>
 
     <!--    Styling    -->

--- a/ApiDemos/project/java-app/build.gradle.kts
+++ b/ApiDemos/project/java-app/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ dependencies {
     implementation(libs.recyclerview)
     implementation(libs.volley)
     implementation(libs.play.services.maps)
+    implementation(libs.play.services.location)
     implementation(libs.material)
     implementation(libs.activity)
     implementation(project(":ApiDemos:common-ui"))

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/CameraClampingDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/CameraClampingDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,13 +31,13 @@ import android.widget.Toast;
  * This shows how to constrain the camera to specific boundaries and zoom levels.
  */
 public class CameraClampingDemoActivity extends SamplesBaseActivity
-        implements OnMapReadyCallback, OnCameraIdleListener {
+        implements OnMapReadyCallback, OnCameraIdleListener, GoogleMap.OnCameraMoveListener {
 
     private static final String TAG = CameraClampingDemoActivity.class.getSimpleName();
 
     private static final float ZOOM_DELTA = 2.0f;
     private static final float DEFAULT_MIN_ZOOM = 2.0f;
-    private static final float DEFAULT_MAX_ZOOM = 22.0f;
+    private static final float DEFAULT_MAX_ZOOM = 21.0f;
 
     static final LatLngBounds ADELAIDE_BOUNDS = new LatLngBounds(
             new LatLng(-35.0, 138.58), new LatLng(-34.9, 138.61));
@@ -71,18 +71,27 @@ public class CameraClampingDemoActivity extends SamplesBaseActivity
 
         mMap = null;
         resetMinMaxZoom();
+        updateZoomLabel(mMinZoom, mMaxZoom);
+
+        binding.zoomRangeSlider.addOnChangeListener((slider, value, fromUser) -> {
+            java.util.List<Float> values = slider.getValues();
+            mMinZoom = values.get(0);
+            mMaxZoom = values.get(1);
+            updateZoomLabel(mMinZoom, mMaxZoom);
+            if (fromUser && mMap != null) {
+                mMap.setMinZoomPreference(mMinZoom);
+                mMap.setMaxZoomPreference(mMaxZoom);
+            }
+        });
 
         binding.clampLatlngAdelaide.setOnClickListener(v -> onClampToAdelaide());
         binding.clampLatlngPacific.setOnClickListener(v -> onClampToPacific());
         binding.clampLatlngReset.setOnClickListener(v -> onLatLngClampReset());
-        binding.clampMinZoom.setOnClickListener(v -> onSetMinZoomClamp());
-        binding.clampMaxZoom.setOnClickListener(v -> onSetMaxZoomClamp());
         binding.clampZoomReset.setOnClickListener(v -> onMinMaxZoomClampReset());
 
         SupportMapFragment mapFragment =
             (SupportMapFragment) getSupportFragmentManager().findFragmentById(com.example.common_ui.R.id.map);
         mapFragment.getMapAsync(this);
-        applyInsets(binding.mapContainer);
     }
 
     @Override
@@ -93,12 +102,36 @@ public class CameraClampingDemoActivity extends SamplesBaseActivity
     @Override
     public void onMapReady(GoogleMap map) {
         mMap = map;
+        map.setOnCameraMoveListener(this);
         map.setOnCameraIdleListener(this);
+        updateCameraPosition();
+    }
+
+    @Override
+    public void onCameraMove() {
+        updateCameraPosition();
     }
 
     @Override
     public void onCameraIdle() {
-        binding.cameraText.setText(mMap.getCameraPosition().toString());
+        updateCameraPosition();
+    }
+
+    private void updateCameraPosition() {
+        if (mMap == null) return;
+        CameraPosition pos = mMap.getCameraPosition();
+        binding.cameraText.setText(getString(
+            com.example.common_ui.R.string.camera_position_format,
+            pos.target.latitude,
+            pos.target.longitude,
+            pos.zoom,
+            pos.tilt,
+            pos.bearing
+        ));
+    }
+
+    private void updateZoomLabel(float min, float max) {
+        binding.zoomLabel.setText(getString(com.example.common_ui.R.string.zoom_bounds_label, min, max));
     }
 
     /**
@@ -126,53 +159,40 @@ public class CameraClampingDemoActivity extends SamplesBaseActivity
         if (!checkReady()) {
             return;
         }
+        binding.latlngClampToggleGroup.check(com.example.common_ui.R.id.clamp_latlng_adelaide);
         mMap.setLatLngBoundsForCameraTarget(ADELAIDE_BOUNDS);
         mMap.animateCamera(CameraUpdateFactory.newCameraPosition(ADELAIDE_CAMERA));
+        binding.clampStatusText.setText(getString(com.example.common_ui.R.string.latlng_clamp_status_adelaide));
     }
 
     private void onClampToPacific() {
         if (!checkReady()) {
             return;
         }
+        binding.latlngClampToggleGroup.check(com.example.common_ui.R.id.clamp_latlng_pacific);
         mMap.setLatLngBoundsForCameraTarget(PACIFIC);
         mMap.animateCamera(CameraUpdateFactory.newCameraPosition(PACIFIC_CAMERA));
+        binding.clampStatusText.setText(getString(com.example.common_ui.R.string.latlng_clamp_status_pacific));
     }
 
     private void onLatLngClampReset() {
         if (!checkReady()) {
             return;
         }
+        binding.latlngClampToggleGroup.clearChecked();
         // Setting bounds to null removes any previously set bounds.
         mMap.setLatLngBoundsForCameraTarget(null);
+        binding.clampStatusText.setText(getString(com.example.common_ui.R.string.latlng_clamp_status_none));
         toast("LatLngBounds clamp reset.");
     }
 
-    private void onSetMinZoomClamp() {
-        if (!checkReady()) {
-            return;
-        }
-        mMinZoom += ZOOM_DELTA;
-        // Constrains the minimum zoom level.
-        mMap.setMinZoomPreference(mMinZoom);
-        toast("Min zoom preference set to: " + mMinZoom);
-    }
-
-    private void onSetMaxZoomClamp() {
-        if (!checkReady()) {
-            return;
-        }
-        mMaxZoom -= ZOOM_DELTA;
-        // Constrains the maximum zoom level.
-        mMap.setMaxZoomPreference(mMaxZoom);
-        toast("Max zoom preference set to: " + mMaxZoom);
-    }
-
     private void onMinMaxZoomClampReset() {
-        if (!checkReady()) {
-            return;
-        }
         resetMinMaxZoom();
-        mMap.resetMinMaxZoomPreference();
+        binding.zoomRangeSlider.setValues(DEFAULT_MIN_ZOOM, DEFAULT_MAX_ZOOM);
+        updateZoomLabel(DEFAULT_MIN_ZOOM, DEFAULT_MAX_ZOOM);
+        if (mMap != null) {
+            mMap.resetMinMaxZoomPreference();
+        }
         toast("Min/Max zoom preferences reset.");
     }
 }

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/EventsDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/EventsDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.google.android.gms.maps.model.LatLng;
 
 import android.os.Bundle;
 import android.widget.TextView;
+import java.util.Locale;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -34,7 +35,7 @@ import androidx.appcompat.app.AppCompatActivity;
 // [START maps_android_sample_events]
 public class EventsDemoActivity extends SamplesBaseActivity
         implements OnMapClickListener, OnMapLongClickListener, OnCameraIdleListener,
-        OnMapReadyCallback {
+        GoogleMap.OnCameraMoveListener, OnMapReadyCallback {
 
     private TextView tapTextView;
     private TextView cameraTextView;
@@ -59,22 +60,51 @@ public class EventsDemoActivity extends SamplesBaseActivity
         this.map = map;
         this.map.setOnMapClickListener(this);
         this.map.setOnMapLongClickListener(this);
+        this.map.setOnCameraMoveListener(this);
         this.map.setOnCameraIdleListener(this);
+        updateCameraPosition();
     }
 
     @Override
     public void onMapClick(LatLng point) {
-        tapTextView.setText("tapped, point=" + point);
+        String lat = String.format(Locale.US, "%.6f", point.latitude);
+        String lng = String.format(Locale.US, "%.6f", point.longitude);
+        tapTextView.setText(getString(com.example.common_ui.R.string.events_tapped_format, lat, lng));
     }
 
     @Override
     public void onMapLongClick(LatLng point) {
-        tapTextView.setText("long pressed, point=" + point);
+        String lat = String.format(Locale.US, "%.6f", point.latitude);
+        String lng = String.format(Locale.US, "%.6f", point.longitude);
+        tapTextView.setText(getString(com.example.common_ui.R.string.events_long_pressed_format, lat, lng));
+    }
+
+    @Override
+    public void onCameraMove() {
+        updateCameraPosition();
     }
 
     @Override
     public void onCameraIdle() {
-        cameraTextView.setText(map.getCameraPosition().toString());
+        updateCameraPosition();
+    }
+
+    private void updateCameraPosition() {
+        if (map == null) return;
+        com.google.android.gms.maps.model.CameraPosition pos = map.getCameraPosition();
+        String lat = String.format(Locale.US, "%.6f", pos.target.latitude);
+        String lng = String.format(Locale.US, "%.6f", pos.target.longitude);
+        String zoom = String.format(Locale.US, "%.1f", pos.zoom);
+        String tilt = String.format(Locale.US, "%.1f", pos.tilt);
+        String bearing = String.format(Locale.US, "%.1f", pos.bearing);
+        cameraTextView.setText(getString(
+            com.example.common_ui.R.string.events_camera_position_format,
+            lat,
+            lng,
+            zoom,
+            tilt,
+            bearing
+        ));
     }
 }
 // [END maps_android_sample_events]

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/LayersDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/LayersDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,6 +88,15 @@ public class LayersDemoActivity extends SamplesBaseActivity
     @Override
     public void onMapReady(GoogleMap map) {
         mMap = map;
+
+        com.google.android.gms.maps.model.CameraPosition initialPosition =
+                new com.google.android.gms.maps.model.CameraPosition.Builder()
+                        .target(new com.google.android.gms.maps.model.LatLng(-33.8688, 151.2093))
+                        .zoom(16.5f)
+                        .tilt(40.0f)
+                        .build();
+        mMap.moveCamera(com.google.android.gms.maps.CameraUpdateFactory.newCameraPosition(initialPosition));
+
         updateMapType();
         updateTraffic();
         updateMyLocation();

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/LocationSourceDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/LocationSourceDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,6 +89,11 @@ public class LocationSourceDemoActivity extends SamplesBaseActivity implements O
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(com.example.common_ui.R.layout.basic_demo);
+
+        androidx.appcompat.widget.Toolbar toolbar = findViewById(com.example.common_ui.R.id.top_bar);
+        if (toolbar != null) {
+            toolbar.setTitle(com.example.common_ui.R.string.location_source_demo_label);
+        }
 
         mLocationSource = new LongPressLocationSource();
 

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/MarkerDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/MarkerDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 
 import com.example.common_ui.R;
@@ -429,7 +430,7 @@ public class MarkerDemoActivity extends SamplesBaseActivity implements
     public boolean onMarkerClick(final Marker marker) {
         if (marker.equals(mPerth)) {
             // This causes the marker at Perth to bounce into position when it is clicked.
-            final Handler handler = new Handler();
+            final Handler handler = new Handler(Looper.getMainLooper());
             final long start = SystemClock.uptimeMillis();
             final long duration = 1500;
 
@@ -485,17 +486,17 @@ public class MarkerDemoActivity extends SamplesBaseActivity implements
 
     @Override
     public void onMarkerDragStart(Marker marker) {
-        binding.topText.setText("onMarkerDragStart");
+        binding.topText.setText(R.string.on_marker_drag_start);
     }
 
     @Override
     public void onMarkerDragEnd(Marker marker) {
-        binding.topText.setText("onMarkerDragEnd");
+        binding.topText.setText(R.string.on_marker_drag_end);
     }
 
     @Override
     public void onMarkerDrag(Marker marker) {
-        binding.topText.setText("onMarkerDrag.  Current Position: " + marker.getPosition());
+        binding.topText.setText(getString(R.string.on_marker_drag, marker.getPosition().latitude, marker.getPosition().longitude));
     }
 
 }

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/SamplesBaseActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/SamplesBaseActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.example.mapdemo;
 import android.os.Bundle;
 import android.view.View;
 
+import android.view.ViewGroup;
+
 import androidx.activity.EdgeToEdge;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -33,18 +35,67 @@ public class SamplesBaseActivity extends AppCompatActivity {
         EdgeToEdge.enable(this);
     }
 
+    @Override
+    public void setContentView(int layoutResID) {
+        super.setContentView(layoutResID);
+        setupEdgeToEdgeInsets();
+    }
+
+    @Override
+    public void setContentView(View view) {
+        super.setContentView(view);
+        setupEdgeToEdgeInsets();
+    }
+
+    @Override
+    public void setContentView(View view, ViewGroup.LayoutParams params) {
+        super.setContentView(view, params);
+        setupEdgeToEdgeInsets();
+    }
+
+    @Override
+    public void addContentView(View view, ViewGroup.LayoutParams params) {
+        super.addContentView(view, params);
+        setupEdgeToEdgeInsets();
+    }
+
+    private void setupEdgeToEdgeInsets() {
+        View root = findViewById(android.R.id.content);
+        if (root == null) return;
+        View topBar = root.findViewById(com.example.common_ui.R.id.top_bar);
+        if (topBar != null) {
+            android.util.TypedValue typedValue = new android.util.TypedValue();
+            int baseHeight;
+            if (getTheme().resolveAttribute(android.R.attr.actionBarSize, typedValue, true)) {
+                baseHeight = android.util.TypedValue.complexToDimensionPixelSize(typedValue.data, getResources().getDisplayMetrics());
+            } else {
+                baseHeight = (int) (56 * getResources().getDisplayMetrics().density);
+            }
+            ViewCompat.setOnApplyWindowInsetsListener(topBar, (view, insets) -> {
+                Insets statusBar = insets.getInsets(WindowInsetsCompat.Type.statusBars() | WindowInsetsCompat.Type.displayCutout());
+                view.setPadding(statusBar.left, statusBar.top, statusBar.right, 0);
+                view.getLayoutParams().height = baseHeight + statusBar.top;
+                view.requestLayout();
+                return insets;
+            });
+        }
+
+        View mapContainer = root.findViewById(com.example.common_ui.R.id.map_container);
+        View bottomTarget = mapContainer != null ? mapContainer : root;
+        ViewCompat.setOnApplyWindowInsetsListener(bottomTarget, (view, insets) -> {
+            Insets navBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars() | WindowInsetsCompat.Type.displayCutout());
+            int topInsets = (topBar == null) ? insets.getInsets(WindowInsetsCompat.Type.statusBars()).top : 0;
+            view.setPadding(navBars.left, topInsets, navBars.right, navBars.bottom);
+            return insets;
+        });
+    }
+
     /**
      * Applies insets to the container view to properly handle window insets.
      *
      * @param container the container view to apply insets to
      */
     protected static void applyInsets(View container) {
-        ViewCompat.setOnApplyWindowInsetsListener(container,
-                (view, insets) -> {
-                    Insets innerPadding = insets.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
-                    view.setPadding(innerPadding.left, innerPadding.top, innerPadding.right, innerPadding.bottom);
-                    return insets;
-                }
-        );
+        // Handled automatically in SamplesBaseActivity
     }
 }

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/StreetViewPanoramaEventsDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/StreetViewPanoramaEventsDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -98,13 +98,13 @@ public class StreetViewPanoramaEventsDemoActivity extends SamplesBaseActivity
     @Override
     public void onStreetViewPanoramaChange(StreetViewPanoramaLocation location) {
         if (location != null) {
-            panoChangeTimesTextView.setText("Times panorama changed=" + ++panoChangeTimes);
+            panoChangeTimesTextView.setText(getString(com.example.common_ui.R.string.pano_change_times, ++panoChangeTimes));
         }
     }
 
     @Override
     public void onStreetViewPanoramaCameraChange(StreetViewPanoramaCamera camera) {
-        panoCameraChangeTextView.setText("Times camera changed=" + ++panoCameraChangeTimes);
+        panoCameraChangeTextView.setText(getString(com.example.common_ui.R.string.pano_camera_change_times, ++panoCameraChangeTimes));
     }
 
     @Override
@@ -113,7 +113,7 @@ public class StreetViewPanoramaEventsDemoActivity extends SamplesBaseActivity
         if (point != null) {
             panoClickTimes++;
             panoClickTextView.setText(
-                    "Times clicked=" + panoClickTimes + " : " + point);
+                    getString(com.example.common_ui.R.string.pano_click_times, panoClickTimes, point));
             streetViewPanorama.animateTo(
                     new StreetViewPanoramaCamera.Builder()
                             .orientation(orientation)
@@ -128,7 +128,7 @@ public class StreetViewPanoramaEventsDemoActivity extends SamplesBaseActivity
         if (point != null) {
             panoLongClickTimes++;
             panoLongClickTextView.setText(
-                    "Times long clicked=" + panoLongClickTimes + " : " + point);
+                    getString(com.example.common_ui.R.string.pano_long_click_times, panoLongClickTimes, point));
         }
     }
 }

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/VisibleRegionDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/VisibleRegionDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package com.example.mapdemo;
 
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 import android.view.View;
 import android.view.animation.Interpolator;
@@ -89,7 +90,8 @@ public class VisibleRegionDemoActivity extends SamplesBaseActivity implements
         // Add a marker to the Opera House.
         mMap.addMarker(new MarkerOptions().position(SOH).title("Sydney Opera House"));
         // Add a camera idle listener.
-        mMap.setOnCameraIdleListener(() -> binding.messageText.setText("CameraChangeListener: " + mMap.getCameraPosition()));
+        mMap.setOnCameraIdleListener(() -> binding.messageText.setText(
+                getString(com.example.common_ui.R.string.camera_change_message, mMap.getCameraPosition())));
     }
 
     /**
@@ -147,7 +149,7 @@ public class VisibleRegionDemoActivity extends SamplesBaseActivity implements
     public void animatePadding(
         final int toLeft, final int toTop, final int toRight, final int toBottom) {
 
-        final Handler handler = new Handler();
+        final Handler handler = new Handler(Looper.getMainLooper());
         final long start = SystemClock.uptimeMillis();
         final long duration = 1000;
 

--- a/ApiDemos/project/java-app/src/v3/java/com/example/mapdemo/MarkerDemoActivity.java
+++ b/ApiDemos/project/java-app/src/v3/java/com/example/mapdemo/MarkerDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 import androidx.annotation.ColorInt;
 import androidx.annotation.DrawableRes;
@@ -435,7 +436,7 @@ public class MarkerDemoActivity extends AppCompatActivity implements
     public boolean onMarkerClick(final Marker marker) {
         if (marker.equals(mPerth)) {
             // This causes the marker at Perth to bounce into position when it is clicked.
-            final Handler handler = new Handler();
+            final Handler handler = new Handler(Looper.getMainLooper());
             final long start = SystemClock.uptimeMillis();
             final long duration = 1500;
 
@@ -491,17 +492,17 @@ public class MarkerDemoActivity extends AppCompatActivity implements
 
     @Override
     public void onMarkerDragStart(Marker marker) {
-        mTopText.setText("onMarkerDragStart");
+        mTopText.setText(com.example.common_ui.R.string.on_marker_drag_start);
     }
 
     @Override
     public void onMarkerDragEnd(Marker marker) {
-        mTopText.setText("onMarkerDragEnd");
+        mTopText.setText(com.example.common_ui.R.string.on_marker_drag_end);
     }
 
     @Override
     public void onMarkerDrag(Marker marker) {
-        mTopText.setText("onMarkerDrag.  Current Position: " + marker.getPosition());
+        mTopText.setText(getString(com.example.common_ui.R.string.on_marker_drag, marker.getPosition().latitude, marker.getPosition().longitude));
     }
 
 }

--- a/ApiDemos/project/java-app/src/v3/java/com/example/mapdemo/VisibleRegionDemoActivity.java
+++ b/ApiDemos/project/java-app/src/v3/java/com/example/mapdemo/VisibleRegionDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import com.google.android.libraries.maps.model.MarkerOptions;
 
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.SystemClock;
 import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
@@ -86,7 +87,8 @@ public class VisibleRegionDemoActivity extends AppCompatActivity implements
         mMap.setOnCameraIdleListener(new OnCameraIdleListener() {
             @Override
             public void onCameraIdle() {
-                mMessageView.setText("CameraChangeListener: " + mMap.getCameraPosition());
+                mMessageView.setText(getString(
+                        com.example.common_ui.R.string.camera_change_message, mMap.getCameraPosition()));
             }
         });
     }
@@ -146,7 +148,7 @@ public class VisibleRegionDemoActivity extends AppCompatActivity implements
     public void animatePadding(
             final int toLeft, final int toTop, final int toRight, final int toBottom) {
 
-        final Handler handler = new Handler();
+        final Handler handler = new Handler(Looper.getMainLooper());
         final long start = SystemClock.uptimeMillis();
         final long duration = 1000;
 

--- a/ApiDemos/project/kotlin-app/build.gradle.kts
+++ b/ApiDemos/project/kotlin-app/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -84,6 +85,7 @@ dependencies {
     implementation(libs.lifecycle.runtime.ktx)
     implementation(libs.maps.ktx)
     implementation(libs.maps.utils.ktx)
+    implementation(libs.play.services.location)
 
     implementation(libs.activity)
 

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/BackgroundColorCustomizationDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/BackgroundColorCustomizationDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ class BackgroundColorCustomizationDemoActivity : SamplesBaseActivity(), OnMapRea
         setContentView(R.layout.background_color_customization_demo)
         val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
         mapFragment?.getMapAsync(this)
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     /**

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/BackgroundColorCustomizationProgrammaticDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/BackgroundColorCustomizationProgrammaticDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ class BackgroundColorCustomizationProgrammaticDemoActivity : SamplesBaseActivity
         } else {
             mapFragment.getMapAsync(this)
         }
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onMapReady(map: GoogleMap) {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/CameraClampingDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/CameraClampingDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,10 +42,6 @@ class CameraClampingDemoActivity : SamplesBaseActivity() {
    * Internal min zoom level that can be toggled via the demo.
    */
   private var minZoom = DEFAULT_MIN_ZOOM
-
-  /**
-   * Internal max zoom level that can be toggled via the demo.
-   */
   private var maxZoom = DEFAULT_MAX_ZOOM
 
   @OptIn(ExperimentalCoroutinesApi::class)
@@ -53,59 +49,80 @@ class CameraClampingDemoActivity : SamplesBaseActivity() {
     super.onCreate(savedInstanceState)
     binding = com.example.common_ui.databinding.CameraClampingDemoBinding.inflate(layoutInflater)
     setContentView(binding.root)
+    updateZoomLabel(minZoom, maxZoom)
     val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment
-    lifecycleScope.launchWhenCreated {
+    lifecycleScope.launch {
       map = mapFragment.awaitMap()
-      launch {
-        map.cameraIdleEvents().collect {
-            onCameraIdle()
-        }
+      updateCameraPosition()
+      map.setOnCameraMoveListener {
+        updateCameraPosition()
       }
-      setButtonClickListeners()
+      map.setOnCameraIdleListener {
+        updateCameraPosition()
+      }
+      setControls()
     }
-    applyInsets(binding.mapContainer)
   }
 
-  private fun setButtonClickListeners() {
-
-    binding.clampMinZoom.setOnClickListener {
-      minZoom += ZOOM_DELTA
-      // Constrains the minimum zoom level.
-      map.setMinZoomPreference(minZoom)
-      toast("Min zoom preference set to: $minZoom")
-    }
-
-    binding.clampMaxZoom.setOnClickListener {
-      maxZoom -= ZOOM_DELTA
-      // Constrains the maximum zoom level.
-      map.setMaxZoomPreference(maxZoom)
-      toast("Max zoom preference set to: $maxZoom")
+  private fun setControls() {
+    binding.zoomRangeSlider.addOnChangeListener { slider, _, fromUser ->
+      val values = slider.values
+      minZoom = values[0]
+      maxZoom = values[1]
+      updateZoomLabel(minZoom, maxZoom)
+      if (fromUser && ::map.isInitialized) {
+        map.setMinZoomPreference(minZoom)
+        map.setMaxZoomPreference(maxZoom)
+      }
     }
 
     binding.clampZoomReset.setOnClickListener {
       resetMinMaxZoom()
-      map.resetMinMaxZoomPreference()
+      binding.zoomRangeSlider.setValues(DEFAULT_MIN_ZOOM, DEFAULT_MAX_ZOOM)
+      updateZoomLabel(DEFAULT_MIN_ZOOM, DEFAULT_MAX_ZOOM)
+      if (::map.isInitialized) {
+        map.resetMinMaxZoomPreference()
+      }
       toast("Min/Max zoom preferences reset.")
     }
 
     binding.clampLatlngAdelaide.setOnClickListener {
+      binding.latlngClampToggleGroup.check(R.id.clamp_latlng_adelaide)
       map.setLatLngBoundsForCameraTarget(ADELAIDE_BOUNDS)
       map.animateCamera(CameraUpdateFactory.newCameraPosition(ADELAIDE_CAMERA))
+      binding.clampStatusText.text = getString(R.string.latlng_clamp_status_adelaide)
     }
 
     binding.clampLatlngPacific.setOnClickListener {
+      binding.latlngClampToggleGroup.check(R.id.clamp_latlng_pacific)
       map.setLatLngBoundsForCameraTarget(PACIFIC)
       map.animateCamera(CameraUpdateFactory.newCameraPosition(PACIFIC_CAMERA))
+      binding.clampStatusText.text = getString(R.string.latlng_clamp_status_pacific)
     }
 
     binding.clampLatlngReset.setOnClickListener {
+      binding.latlngClampToggleGroup.clearChecked()
       map.setLatLngBoundsForCameraTarget(null)
+      binding.clampStatusText.text = getString(R.string.latlng_clamp_status_none)
       toast("LatLngBounds clamp reset.")
     }
   }
 
-  private fun onCameraIdle() {
-    binding.cameraText.text = map.cameraPosition.toString()
+  private fun updateZoomLabel(min: Float, max: Float) {
+    binding.zoomLabel.text = getString(R.string.zoom_bounds_label, min, max)
+  }
+
+  private fun updateCameraPosition() {
+    if (!::map.isInitialized) return
+    val pos = map.cameraPosition
+    binding.cameraText.text = getString(
+      R.string.camera_position_format,
+      pos.target.latitude,
+      pos.target.longitude,
+      pos.zoom,
+      pos.tilt,
+      pos.bearing
+    )
   }
 
   private fun toast(msg: String) {
@@ -121,7 +138,7 @@ class CameraClampingDemoActivity : SamplesBaseActivity() {
     private val TAG = CameraClampingDemoActivity::class.java.name
     private const val ZOOM_DELTA = 2.0f
     private const val DEFAULT_MIN_ZOOM = 2.0f
-    private const val DEFAULT_MAX_ZOOM = 22.0f
+    private const val DEFAULT_MAX_ZOOM = 21.0f
     val ADELAIDE_BOUNDS = LatLngBounds(
       LatLng(-35.0, 138.58), LatLng(-34.9, 138.61))
     private val ADELAIDE_CAMERA = CameraPosition.Builder()

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/CloudBasedMapStylingDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/CloudBasedMapStylingDemoActivity.kt
@@ -6,7 +6,7 @@
  * corresponding file under the `app/src/gms` directory.
  */
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class CloudBasedMapStylingDemoActivity : SamplesBaseActivity(), OnMapReadyCallba
         val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
         mapFragment!!.getMapAsync(this)
         setUpButtonListeners()
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onMapReady(map: GoogleMap) {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/DataDrivenBoundariesActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/DataDrivenBoundariesActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ class DataDrivenBoundariesActivity : SamplesBaseActivity(), OnMapReadyCallback,
         setupBoundarySelectorButton() // Setup the new selector button
 
         // --- Insets ---
-        applyInsets(findViewById<View>(R.id.map_container)) // Apply insets if needed
+        applyInsets(findViewById(R.id.map_container)) // Apply insets if needed
     }
 
     private fun setupBoundarySelectorButton() {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/EventsDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/EventsDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.TextView
 import com.example.common_ui.R
+import java.util.Locale
 
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMap.*
@@ -29,7 +30,7 @@ import com.google.android.gms.maps.model.LatLng
  */
 // [START maps_android_sample_events]
 class EventsDemoActivity : SamplesBaseActivity(), OnMapClickListener,
-    OnMapLongClickListener, OnCameraIdleListener, OnMapReadyCallback {
+    OnMapLongClickListener, OnCameraIdleListener, OnCameraMoveListener, OnMapReadyCallback {
 
     private lateinit var tapTextView: TextView
     private lateinit var cameraTextView: TextView
@@ -42,28 +43,47 @@ class EventsDemoActivity : SamplesBaseActivity(), OnMapClickListener,
         cameraTextView = findViewById(R.id.camera_text)
         val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
         mapFragment?.getMapAsync(this)
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onMapReady(googleMap: GoogleMap) {
-        // return early if the map was not initialised properly
         map = googleMap
         map.setOnMapClickListener(this)
         map.setOnMapLongClickListener(this)
+        map.setOnCameraMoveListener(this)
         map.setOnCameraIdleListener(this)
+        updateCameraPosition()
     }
 
     override fun onMapClick(point: LatLng) {
-        tapTextView.text = "tapped, point=$point"
+        val lat = String.format(Locale.US, "%.6f", point.latitude)
+        val lng = String.format(Locale.US, "%.6f", point.longitude)
+        tapTextView.text = getString(R.string.events_tapped_format, lat, lng)
     }
 
     override fun onMapLongClick(point: LatLng) {
-        tapTextView.text = "long pressed, point=$point"
+        val lat = String.format(Locale.US, "%.6f", point.latitude)
+        val lng = String.format(Locale.US, "%.6f", point.longitude)
+        tapTextView.text = getString(R.string.events_long_pressed_format, lat, lng)
+    }
+
+    override fun onCameraMove() {
+        updateCameraPosition()
     }
 
     override fun onCameraIdle() {
+        updateCameraPosition()
+    }
+
+    private fun updateCameraPosition() {
         if (!::map.isInitialized) return
-        cameraTextView.text = map.cameraPosition.toString()
+        val pos = map.cameraPosition
+        val lat = String.format(Locale.US, "%.6f", pos.target.latitude)
+        val lng = String.format(Locale.US, "%.6f", pos.target.longitude)
+        val zoom = String.format(Locale.US, "%.1f", pos.zoom)
+        val tilt = String.format(Locale.US, "%.1f", pos.tilt)
+        val bearing = String.format(Locale.US, "%.1f", pos.bearing)
+        cameraTextView.text = getString(R.string.events_camera_position_format, lat, lng, zoom, tilt, bearing)
     }
 }
 // [END maps_android_sample_events]

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/LayersDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/LayersDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import android.widget.CheckBox
 import android.widget.Spinner
 import com.example.common_ui.R
 
+import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMap.MAP_TYPE_HYBRID
 import com.google.android.gms.maps.GoogleMap.MAP_TYPE_NONE
@@ -36,6 +37,8 @@ import com.google.android.gms.maps.GoogleMap.MAP_TYPE_SATELLITE
 import com.google.android.gms.maps.GoogleMap.MAP_TYPE_TERRAIN
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
 import pub.devrel.easypermissions.AfterPermissionGranted
 import pub.devrel.easypermissions.EasyPermissions
 
@@ -105,6 +108,13 @@ class LayersDemoActivity :
     @SuppressLint("MissingPermission")
     override fun onMapReady(googleMap: GoogleMap) {
         map = googleMap
+
+        val initialPosition = CameraPosition.builder()
+            .target(LatLng(-33.8688, 151.2093))
+            .zoom(16.5f)
+            .tilt(40.0f)
+            .build()
+        map.moveCamera(CameraUpdateFactory.newCameraPosition(initialPosition))
 
         updateMapType()
 

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/LocationSourceDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/LocationSourceDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,9 +21,8 @@ import android.os.Bundle
 import android.view.View
 
 import androidx.core.app.ActivityCompat
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.example.common_ui.R
 import com.google.android.gms.maps.GoogleMap
@@ -33,6 +32,8 @@ import com.google.android.gms.maps.LocationSource.OnLocationChangedListener
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.ktx.awaitMap
+
+import kotlinx.coroutines.launch
 
 /**
  * This shows how to use a custom location source.
@@ -44,13 +45,14 @@ class LocationSourceDemoActivity : SamplesBaseActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.basic_demo)
+    findViewById<com.google.android.material.appbar.MaterialToolbar>(R.id.top_bar)?.setTitle(R.string.location_source_demo_label)
     val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment
-    lifecycleScope.launchWhenCreated {
+    lifecycleScope.launch {
       val map = mapFragment.awaitMap()
       init(map = map)
     }
     lifecycle.addObserver(locationSource)
-    applyInsets(findViewById<View>(R.id.map_container))
+    applyInsets(findViewById(R.id.map_container))
   }
 
   @SuppressLint("MissingPermission")
@@ -72,7 +74,7 @@ class LocationSourceDemoActivity : SamplesBaseActivity() {
  * at
  * the point at which a user long pressed the map.
  */
-private class LongPressLocationSource : LocationSource, OnMapLongClickListener, LifecycleObserver {
+private class LongPressLocationSource : LocationSource, OnMapLongClickListener, DefaultLifecycleObserver {
 
   private var listener: OnLocationChangedListener? = null
 
@@ -104,13 +106,11 @@ private class LongPressLocationSource : LocationSource, OnMapLongClickListener, 
     listener?.onLocationChanged(location)
   }
 
-  @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-  fun onPause() {
+  override fun onPause(owner: LifecycleOwner) {
     paused = true
   }
 
-  @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-  fun onResume() {
+  override fun onResume(owner: LifecycleOwner) {
     paused = false
   }
 }

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MapColorSchemeActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MapColorSchemeActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class MapColorSchemeActivity :
         buttonLight = findViewById(R.id.map_color_light_mode)
         buttonDark = findViewById(R.id.map_color_dark_mode)
         buttonFollowSystem = findViewById(R.id.map_color_follow_system_mode)
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onMapReady(googleMap: GoogleMap) {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MapInPagerDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MapInPagerDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class MapInPagerDemoActivity : SamplesBaseActivity() {
     // This is required to avoid a black flash when the map is loaded.  The flash is due
     // to the use of a SurfaceView as the underlying view of the map.
     pager.requestTransparentRegion(pager)
-    applyInsets(findViewById<View>(R.id.map_container))
+    applyInsets(findViewById(R.id.map_container))
   }
 
   /** A simple fragment that displays a TextView.  */
@@ -55,6 +55,7 @@ class MapInPagerDemoActivity : SamplesBaseActivity() {
   }
 
   /** A simple FragmentPagerAdapter that returns two TextFragment and a SupportMapFragment.  */
+  @Suppress("DEPRECATION")
   class MyAdapter(fm: FragmentManager) :
     FragmentPagerAdapter(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
 

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MarkerCloseInfoWindowOnRetapDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MarkerCloseInfoWindowOnRetapDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ class MarkerCloseInfoWindowOnRetapDemoActivity :
 
     val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment
     OnMapAndViewReadyListener(mapFragment, this)
-    applyInsets(findViewById<View>(R.id.map_container))
+    applyInsets(findViewById(R.id.map_container))
   }
 
   override fun onMapReady(googleMap: GoogleMap?) {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MarkerDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MarkerDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
@@ -36,7 +37,9 @@ import android.widget.Toast
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.graphics.toColorInt
 import com.example.common_ui.R
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
@@ -290,7 +293,7 @@ class MarkerDemoActivity :
                         position = places.getValue("ALICE_SPRINGS"),
                         title = "Alice Springs",
                         icon = vectorToBitmap(
-                                R.drawable.ic_android, Color.parseColor("#A4C639"))
+                                R.drawable.ic_android, "#A4C639".toColorInt())
                 ),
 
                 // More markers for good measure
@@ -363,8 +366,11 @@ class MarkerDemoActivity :
             Log.e(TAG, "Resource not found")
             return BitmapDescriptorFactory.defaultMarker()
         }
-        val bitmap = Bitmap.createBitmap(vectorDrawable.intrinsicWidth,
-                vectorDrawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+        val bitmap = createBitmap(
+            vectorDrawable.intrinsicWidth,
+            vectorDrawable.intrinsicHeight,
+            Bitmap.Config.ARGB_8888
+        )
         val canvas = Canvas(bitmap)
         vectorDrawable.setBounds(0, 0, canvas.width, canvas.height)
         DrawableCompat.setTint(vectorDrawable, color)
@@ -401,7 +407,7 @@ class MarkerDemoActivity :
 
         if (marker.position == places.getValue("PERTH")) {
             // This causes the marker at Perth to bounce into position when it is clicked.
-            val handler = Handler()
+            val handler = Handler(Looper.getMainLooper())
             val start = SystemClock.uptimeMillis()
             val duration = 1500
 

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MultiMapDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MultiMapDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,6 @@ class MultiMapDemoActivity : SamplesBaseActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.multimap_demo)
-    applyInsets(findViewById<View>(R.id.map_container))
+    applyInsets(findViewById(R.id.map_container))
   }
 }

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MyLocationDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/MyLocationDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class MyLocationDemoActivity : SamplesBaseActivity(),
         val mapFragment =
             supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
         mapFragment?.getMapAsync(this)
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onMapReady(googleMap: GoogleMap) {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/OnMapAndViewReadyListener.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/OnMapAndViewReadyListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class OnMapAndViewReadyListener(
 ) : OnGlobalLayoutListener,
         OnMapReadyCallback {
 
-    private val mapView: View? = mapFragment.view
+    private var mapView: View? = null
 
     private var isViewReady = false
     private var isMapReady = false
@@ -52,16 +52,6 @@ class OnMapAndViewReadyListener(
     }
 
     private fun registerListeners() {
-        // View layout.
-        mapView?.let {
-            if (it.width != 0 && it.height != 0) {
-                // View has already completed layout.
-                isViewReady = true
-            } else {
-                // Map has not undergone layout, register a View observer.
-                it.viewTreeObserver.addOnGlobalLayoutListener(this)
-            }
-        }
         // GoogleMap. Note if the GoogleMap is already ready it will still fire the callback later.
         mapFragment.getMapAsync(this)
     }
@@ -70,6 +60,22 @@ class OnMapAndViewReadyListener(
         // NOTE: The GoogleMap API specifies the listener is removed just prior to invocation.
         map = googleMap
         isMapReady = true
+
+        // View layout.
+        mapView = mapFragment.view
+        val view = mapView
+        if (view != null) {
+            if (view.width != 0 && view.height != 0) {
+                // View has already completed layout.
+                isViewReady = true
+            } else {
+                // Map has not undergone layout, register a View observer.
+                view.viewTreeObserver.addOnGlobalLayoutListener(this)
+            }
+        } else {
+            isViewReady = true
+        }
+
         fireCallbackIfReady()
     }
 

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/PolygonDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/PolygonDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ class PolygonDemoActivity :
 
         val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment
         mapFragment.getMapAsync(this)
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
     // [START_EXCLUDE silent]
 

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/PolylineDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/PolylineDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ class PolylineDemoActivity :
 
         val mapFragment = supportFragmentManager.findFragmentById(com.example.common_ui.R.id.map) as SupportMapFragment
         mapFragment.getMapAsync(this)
-        applyInsets(findViewById<View>(com.example.common_ui.R.id.map_container))
+        applyInsets(findViewById(com.example.common_ui.R.id.map_container))
     }
     // [START_EXCLUDE silent]
 
@@ -165,8 +165,6 @@ class PolylineDemoActivity :
     // [END_EXCLUDE]
 
     override fun onMapReady(googleMap: GoogleMap) {
-        googleMap
-
         with(googleMap) {
             // Override the default content description on the view, for accessibility mode.
             setContentDescription(getString(com.example.common_ui.R.string.polyline_demo_description))

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/ProgrammaticDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/ProgrammaticDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.example.kotlindemos
 
-import android.R
 import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.lifecycleScope
@@ -21,6 +20,7 @@ import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.ktx.addMarker
 import com.google.maps.android.ktx.awaitMap
+import kotlinx.coroutines.launch
 
 /**
  * Demonstrates how to instantiate a SupportMapFragment programmatically and add a marker to it.
@@ -36,18 +36,18 @@ class ProgrammaticDemoActivity : SamplesBaseActivity() {
                 ?: SupportMapFragment.newInstance().also {
                     // Then we add it using a FragmentTransaction.
                     val fragmentTransaction = supportFragmentManager.beginTransaction()
-                    fragmentTransaction.add(R.id.content, it, MAP_FRAGMENT_TAG)
+                    fragmentTransaction.add(android.R.id.content, it, MAP_FRAGMENT_TAG)
                     fragmentTransaction.commit()
                 }
 
-        lifecycleScope.launchWhenCreated {
+        lifecycleScope.launch {
             val map = mapFragment.awaitMap()
             map.addMarker {
                 position(LatLng(0.0, 0.0))
                 title("Marker")
             }
         }
-      applyInsets(findViewById<View>(com.example.common_ui.R.id.map_container))
+        applyInsets(findViewById(com.example.common_ui.R.id.map_container))
     }
 
     companion object {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/RetainMapDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/RetainMapDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.ktx.addMarker
 import com.google.maps.android.ktx.awaitMap
+import kotlinx.coroutines.launch
 
 /**
  * This shows how to retain a map across activity restarts (e.g., from screen rotations), which can
@@ -34,15 +35,16 @@ class RetainMapDemoActivity : SamplesBaseActivity() {
             supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment
         if (savedInstanceState == null) {
             // First incarnation of this activity.
+            @Suppress("DEPRECATION")
             mapFragment.retainInstance = true
         }
-        lifecycleScope.launchWhenCreated {
+        lifecycleScope.launch {
             val map = mapFragment.awaitMap()
             map.addMarker {
                 position(LatLng(0.0, 0.0))
                 title("Marker")
             }
         }
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 }

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SamplesBaseActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SamplesBaseActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@ package com.example.kotlindemos
 
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.OnApplyWindowInsetsListener
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 
@@ -27,27 +27,81 @@ open class SamplesBaseActivity : AppCompatActivity() {
         enableEdgeToEdge()
     }
 
+    override fun setContentView(layoutResID: Int) {
+        super.setContentView(layoutResID)
+        setupEdgeToEdgeInsets()
+    }
+
+    override fun setContentView(view: View?) {
+        super.setContentView(view)
+        setupEdgeToEdgeInsets()
+    }
+
+    override fun setContentView(view: View?, params: ViewGroup.LayoutParams?) {
+        super.setContentView(view, params)
+        setupEdgeToEdgeInsets()
+    }
+
+    override fun addContentView(view: View?, params: ViewGroup.LayoutParams?) {
+        super.addContentView(view, params)
+        setupEdgeToEdgeInsets()
+    }
+
+    private fun setupEdgeToEdgeInsets() {
+        val root = findViewById<View>(android.R.id.content) ?: return
+        val topBar = root.findViewById<View>(com.example.common_ui.R.id.top_bar)
+        if (topBar != null) {
+            val typedValue = android.util.TypedValue()
+            val baseHeight = if (theme.resolveAttribute(android.R.attr.actionBarSize, typedValue, true)) {
+                android.util.TypedValue.complexToDimensionPixelSize(typedValue.data, resources.displayMetrics)
+            } else {
+                (56 * resources.displayMetrics.density).toInt()
+            }
+            ViewCompat.setOnApplyWindowInsetsListener(topBar) { view, insets ->
+                val statusBar = insets.getInsets(
+                    WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout()
+                )
+                view.setPadding(
+                    statusBar.left,
+                    statusBar.top,
+                    statusBar.right,
+                    0
+                )
+                view.layoutParams.height = baseHeight + statusBar.top
+                view.requestLayout()
+                insets
+            }
+        }
+
+        val mapContainer = root.findViewById<View>(com.example.common_ui.R.id.map_container)
+        val bottomTarget = mapContainer ?: root
+        ViewCompat.setOnApplyWindowInsetsListener(bottomTarget) { view, insets ->
+            val navBars = insets.getInsets(
+                WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            val topInsets = if (topBar == null) {
+                insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
+            } else {
+                0
+            }
+            view.setPadding(
+                navBars.left,
+                topInsets,
+                navBars.right,
+                navBars.bottom
+            )
+            insets
+        }
+    }
+
     companion object {
         /**
          * Applies insets to the container view to properly handle window insets.
          *
          * @param container the container view to apply insets to
          */
-        fun applyInsets(container: View) {
-            ViewCompat.setOnApplyWindowInsetsListener(
-                container,
-                OnApplyWindowInsetsListener { view: View?, insets: WindowInsetsCompat? ->
-                    val innerPadding =
-                        insets!!.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
-                    view!!.setPadding(
-                        innerPadding.left,
-                        innerPadding.top,
-                        innerPadding.right,
-                        innerPadding.bottom
-                    )
-                    insets
-                }
-            )
+        fun applyInsets(container: View? = null) {
+            // Handled automatically in SamplesBaseActivity
         }
     }
 }

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SaveStateDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SaveStateDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package com.example.kotlindemos
 import android.os.Bundle
 import android.os.Parcelable
 
+import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap.OnMarkerClickListener
@@ -26,7 +27,8 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.maps.android.ktx.addMarker
 import com.google.maps.android.ktx.awaitMap
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
+import kotlinx.coroutines.launch
 import java.util.Random
 
 /**
@@ -73,13 +75,15 @@ class SaveStateDemoActivity : SamplesBaseActivity() {
       //   the savedInsanceState Bundle.
       // - Custom Parcelable objects were wrapped in another Bundle.
       mMarkerPosition =
-        savedInstanceState?.getParcelable(MARKER_POSITION) ?: DEFAULT_MARKER_POSITION
+        savedInstanceState?.let { BundleCompat.getParcelable(it, MARKER_POSITION, LatLng::class.java) }
+          ?: DEFAULT_MARKER_POSITION
       mMarkerInfo =
-        savedInstanceState?.getBundle(OTHER_OPTIONS)?.getParcelable(MARKER_INFO) ?: MarkerInfo(
-          BitmapDescriptorFactory.HUE_RED)
+        savedInstanceState?.getBundle(OTHER_OPTIONS)?.let {
+          BundleCompat.getParcelable(it, MARKER_INFO, MarkerInfo::class.java)
+        } ?: MarkerInfo(BitmapDescriptorFactory.HUE_RED)
       mMoveCameraToMarker = savedInstanceState == null
 
-      lifecycleScope.launchWhenCreated {
+      lifecycleScope.launch {
         val map = awaitMap()
         map.addMarker {
           icon(BitmapDescriptorFactory.defaultMarker(mMarkerInfo.hue))

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaBasicDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaBasicDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class StreetViewPanoramaBasicDemoActivity : SamplesBaseActivity() {
             // loaded which is when the savedInstanceState is null).
             savedInstanceState ?: panorama.setPosition(SYDNEY)
         }
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     companion object {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaEventsDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaEventsDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,22 +74,22 @@ class StreetViewPanoramaEventsDemoActivity : SamplesBaseActivity(),
             // loaded which is when the savedInstanceState is null).
             savedInstanceState ?: streetViewPanorama.setPosition(SYDNEY)
         }
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onStreetViewPanoramaChange(location: StreetViewPanoramaLocation) {
-        panoChangeTimesTextView.text = "Times panorama changed=" + ++panoChangeTimes
+        panoChangeTimesTextView.text = getString(R.string.pano_change_times, ++panoChangeTimes)
     }
 
     override fun onStreetViewPanoramaCameraChange(camera: StreetViewPanoramaCamera) {
-        panoCameraChangeTextView.text = "Times camera changed=" + ++panoCameraChangeTimes
+        panoCameraChangeTextView.text = getString(R.string.pano_camera_change_times, ++panoCameraChangeTimes)
     }
 
     override fun onStreetViewPanoramaClick(orientation: StreetViewPanoramaOrientation) {
         val point = streetViewPanorama.orientationToPoint(orientation)
         point?.let {
             panoClickTimes++
-            panoClickTextView.text = "Times clicked=$panoClickTimes : $point"
+            panoClickTextView.text = getString(R.string.pano_click_times, panoClickTimes, it)
             streetViewPanorama.animateTo(
                 StreetViewPanoramaCamera.Builder()
                     .orientation(orientation)
@@ -103,7 +103,7 @@ class StreetViewPanoramaEventsDemoActivity : SamplesBaseActivity(),
         val point = streetViewPanorama.orientationToPoint(orientation)
         if (point != null) {
             panoLongClickTimes++
-            panoLongClickTextView.text = "Times long clicked=$panoLongClickTimes : $point"
+            panoLongClickTextView.text = getString(R.string.pano_long_click_times, panoLongClickTimes, point)
         }
     }
 

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaNavigationDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaNavigationDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -190,7 +190,7 @@ class StreetViewPanoramaNavigationDemoActivity : SamplesBaseActivity() {
     private fun onMovePosition() {
         val location = streetViewPanorama.location
         val camera = streetViewPanorama.panoramaCamera
-        location.links?.let {
+        if (location.links.isNotEmpty()) {
             val link = location.links.findClosestLinkToBearing(camera.bearing)
             streetViewPanorama.setPosition(link.panoId)
         }

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaViewDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StreetViewPanoramaViewDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class StreetViewPanoramaViewDemoActivity : SamplesBaseActivity() {
         // StreetViewPanoramaView requires that the Bundle you pass contain _ONLY_
         // StreetViewPanoramaView SDK objects or sub-Bundles.
         streetViewPanoramaView.onCreate(savedInstanceState?.getBundle(STREETVIEW_BUNDLE_KEY))
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onResume() {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StyledMapDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/StyledMapDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class StyledMapDemoActivity : SamplesBaseActivity(), OnMapReadyCallback {
         val mapFragment =
                 supportFragmentManager.findFragmentById(com.example.common_ui.R.id.map) as SupportMapFragment
         mapFragment.getMapAsync(this)
-        applyInsets(findViewById<View>(com.example.common_ui.R.id.map_container))
+        applyInsets(findViewById(com.example.common_ui.R.id.map_container))
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/TagsDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/TagsDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ class TagsDemoActivity : SamplesBaseActivity(),
 
         val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment
         OnMapAndViewReadyListener(mapFragment, this)
-        applyInsets(findViewById<View>(R.id.map_container))
+        applyInsets(findViewById(R.id.map_container))
     }
 
     override fun onMapReady(googleMap: GoogleMap?) {

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/VisibleRegionDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/VisibleRegionDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.example.kotlindemos
 
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.view.View
 import android.view.animation.OvershootInterpolator
@@ -121,7 +122,7 @@ class VisibleRegionDemoActivity :
     // this function smoothly changes the amount of padding over a period of time
     private fun animatePadding(toLeft: Int, toTop: Int, toRight: Int, toBottom: Int) {
 
-        val handler = Handler()
+        val handler = Handler(Looper.getMainLooper())
         val start = SystemClock.uptimeMillis()
         val duration: Long = 1000
 

--- a/ApiDemos/project/kotlin-app/src/main/res/layout/save_state_demo.xml
+++ b/ApiDemos/project/kotlin-app/src/main/res/layout/save_state_demo.xml
@@ -22,44 +22,30 @@
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/top_bar"
         style="@style/Widget.MaterialComponents.Toolbar.Primary"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:title="@string/events_demo_label" />
+        app:title="@string/save_state_demo_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/instructions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/save_state_instructions"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/map"
-        android:name="com.google.android.gms.maps.SupportMapFragment"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintTop_toBottomOf="@+id/top_bar" />
-
-    <LinearLayout
-        android:id="@+id/events_info_panel"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="?attr/colorSurface"
-        android:orientation="vertical"
-        android:padding="12dp"
+        class="com.example.kotlindemos.SaveStateDemoActivity$SaveStateMapFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/top_bar">
+        app:layout_constraintTop_toBottomOf="@id/instructions" />
 
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/tap_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textAppearance="?attr/textAppearanceBodyMedium"
-            android:text="@string/tap_instructions" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/camera_text"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:textAppearance="?attr/textAppearanceBodyMedium"
-            android:text="@string/move_the_camera" />
-    </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/project/kotlin-app/src/v3/java/com/example/kotlindemos/MarkerDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/v3/java/com/example/kotlindemos/MarkerDemoActivity.kt
@@ -6,7 +6,7 @@
  * corresponding file under the `app/src/gms` directory.
  */
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
@@ -46,7 +47,9 @@ import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.graphics.toColorInt
 import com.google.android.libraries.maps.CameraUpdateFactory
 import com.google.android.libraries.maps.GoogleMap
 import com.google.android.libraries.maps.GoogleMap.InfoWindowAdapter
@@ -299,7 +302,7 @@ class MarkerDemoActivity :
                         position = places.getValue("ALICE_SPRINGS"),
                         title = "Alice Springs",
                         icon = vectorToBitmap(
-                                com.example.common_ui.R.drawable.ic_android, Color.parseColor("#A4C639"))
+                                com.example.common_ui.R.drawable.ic_android, "#A4C639".toColorInt())
                 ),
 
                 // More markers for good measure
@@ -371,8 +374,11 @@ class MarkerDemoActivity :
             Log.e(TAG, "Resource not found")
             return BitmapDescriptorFactory.defaultMarker()
         }
-        val bitmap = Bitmap.createBitmap(vectorDrawable.intrinsicWidth,
-                vectorDrawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+        val bitmap = createBitmap(
+            vectorDrawable.intrinsicWidth,
+            vectorDrawable.intrinsicHeight,
+            Bitmap.Config.ARGB_8888
+        )
         val canvas = Canvas(bitmap)
         vectorDrawable.setBounds(0, 0, canvas.width, canvas.height)
         DrawableCompat.setTint(vectorDrawable, color)
@@ -415,7 +421,7 @@ class MarkerDemoActivity :
 
         if (marker.position == places.getValue("PERTH")) {
             // This causes the marker at Perth to bounce into position when it is clicked.
-            val handler = Handler()
+            val handler = Handler(Looper.getMainLooper())
             val start = SystemClock.uptimeMillis()
             val duration = 1500
 

--- a/ApiDemos/project/kotlin-app/src/v3/java/com/example/kotlindemos/OnMapAndViewReadyListener.kt
+++ b/ApiDemos/project/kotlin-app/src/v3/java/com/example/kotlindemos/OnMapAndViewReadyListener.kt
@@ -6,7 +6,7 @@
  * corresponding file under the `app/src/gms` directory.
  */
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class OnMapAndViewReadyListener(
 ) : OnGlobalLayoutListener,
         OnMapReadyCallback {
 
-    private val mapView: View? = mapFragment.view
+    private var mapView: View? = null
 
     private var isViewReady = false
     private var isMapReady = false
@@ -59,15 +59,6 @@ class OnMapAndViewReadyListener(
     }
 
     private fun registerListeners() {
-        // View layout.
-        if (mapView?.width != 0 && mapView?.height != 0) {
-            // View has already completed layout.
-            isViewReady = true
-        } else {
-            // Map has not undergone layout, register a View observer.
-            mapView.viewTreeObserver.addOnGlobalLayoutListener(this)
-        }
-
         // GoogleMap. Note if the GoogleMap is already ready it will still fire the callback later.
         mapFragment.getMapAsync(this)
     }
@@ -76,6 +67,22 @@ class OnMapAndViewReadyListener(
         // NOTE: The GoogleMap API specifies the listener is removed just prior to invocation.
         map = googleMap ?: return
         isMapReady = true
+
+        // View layout.
+        mapView = mapFragment.view
+        val view = mapView
+        if (view != null) {
+            if (view.width != 0 && view.height != 0) {
+                // View has already completed layout.
+                isViewReady = true
+            } else {
+                // Map has not undergone layout, register a View observer.
+                view.viewTreeObserver.addOnGlobalLayoutListener(this)
+            }
+        } else {
+            isViewReady = true
+        }
+
         fireCallbackIfReady()
     }
 

--- a/ApiDemos/project/kotlin-app/src/v3/java/com/example/kotlindemos/VisibleRegionDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/v3/java/com/example/kotlindemos/VisibleRegionDemoActivity.kt
@@ -6,7 +6,7 @@
  * corresponding file under the `app/src/gms` directory.
  */
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ package com.example.kotlindemos
 
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.view.View
 import android.view.animation.OvershootInterpolator
@@ -131,7 +132,7 @@ class VisibleRegionDemoActivity :
     // this function smoothly changes the amount of padding over a period of time
     private fun animatePadding(toLeft: Int, toTop: Int, toRight: Int, toBottom: Int) {
 
-        val handler = Handler()
+        val handler = Handler(Looper.getMainLooper())
         val start = SystemClock.uptimeMillis()
         val duration: Long = 1000
 


### PR DESCRIPTION
### Summary

- **Edge-to-Edge System Insets**: Update `SamplesBaseActivity` in both Kotlin and Java to safely apply window insets to root view containers and programmatic layouts without double-padding nested fragment views.
- **SaveState Demo**: Add missing `save_state_demo.xml` layout and wire up `SaveStateDemoActivity.kt`.
- **LocationSource Demo**: Ensure `LocationSourceDemoActivity` displays its dedicated toolbar title.
- **Lint & Modernization**: Clean up lint warnings, string templates, borderless button styles, and layout constraints across standard map demos.

Part of stack: #2390 -> #2391