### PR TITLE
feat(streetview): modernize SplitStreetView demo with My Location FAB and bidirectional sync

### DIFF
--- a/ApiDemos/project/common-ui/src/main/res/drawable/ic_my_location.xml
+++ b/ApiDemos/project/common-ui/src/main/res/drawable/ic_my_location.xml
@@ -1,0 +1,25 @@
+<!--
+     Copyright 2026 Google LLC
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8c-2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4 -1.79,-4 -4,-4zM20.94,11A8.994,8.994 0,0 0,13 3.06V1h-2v2.06A8.994,8.994 0,0 0,3.06 11H1v2h2.06A8.994,8.994 0,0 0,11 20.94V23h2v-2.06A8.994,8.994 0,0 0,20.94 13H23v-2h-2.06zM12,19c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/ApiDemos/project/common-ui/src/main/res/layout/split_street_view_panorama_and_map_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/split_street_view_panorama_and_map_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -31,15 +31,28 @@
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/split_street_view_panorama_and_map_demo_label" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/instructions"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurfaceVariant"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:padding="8dp"
+        android:gravity="center"
+        android:text="@string/split_street_view_instructions"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/streetviewpanorama"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:name="com.google.android.gms.maps.SupportStreetViewPanoramaFragment"
-        app:layout_constraintTop_toBottomOf="@id/topAppBar"
+        app:layout_constraintTop_toBottomOf="@id/instructions"
+        app:layout_constraintBottom_toTopOf="@id/map"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.5" />
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/map"
@@ -47,8 +60,20 @@
         android:layout_height="0dp"
         android:name="com.google.android.gms.maps.SupportMapFragment"
         app:layout_constraintTop_toBottomOf="@id/streetviewpanorama"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHeight_percent="0.5" />
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/btn_my_location"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:contentDescription="@string/my_location"
+        app:srcCompat="@drawable/ic_my_location"
+        app:fabSize="mini"
+        app:layout_constraintBottom_toBottomOf="@id/map"
+        app:layout_constraintEnd_toEndOf="@id/map" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/SplitStreetViewPanoramaAndMapDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/SplitStreetViewPanoramaAndMapDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,22 @@
 
 package com.example.mapdemo;
 
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.content.pm.PackageManager;
+import android.location.Location;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.Priority;
+import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMap.OnMarkerDragListener;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -28,30 +44,45 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.StreetViewPanoramaLocation;
-
-import android.os.Bundle;
-
-import androidx.appcompat.app.AppCompatActivity;
+import com.google.android.gms.tasks.CancellationTokenSource;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 /**
- * This shows how to create a simple activity with streetview and a map
+ * Demonstrates bidirectional synchronization between a {@link SupportStreetViewPanoramaFragment}
+ * (top pane) and a {@link SupportMapFragment} (bottom pane).
+ *
+ * Key concepts illustrated:
+ * 1. **Map-to-Street View Sync**: Long-pressing and dragging the yellow "Pegman" marker on the map
+ *    updates the Street View panorama to match the new drop coordinates.
+ * 2. **Street View-to-Map Sync**: Navigating within Street View (tapping forward arrows/chevrons)
+ *    updates Pegman's position on the map and smoothly pans the map camera to follow.
+ * 3. **High-Accuracy Location**: Uses {@link FusedLocationProviderClient} with {@link Priority#PRIORITY_HIGH_ACCURACY}
+ *    to teleport Pegman and Street View to the user's real-time physical location on demand.
  */
 public class SplitStreetViewPanoramaAndMapDemoActivity extends SamplesBaseActivity
-        implements OnMarkerDragListener, OnStreetViewPanoramaChangeListener {
+        implements OnMarkerDragListener, OnStreetViewPanoramaChangeListener,
+        ActivityCompat.OnRequestPermissionsResultCallback {
 
+    private static final int LOCATION_PERMISSION_REQUEST_CODE = 1;
     private static final String MARKER_POSITION_KEY = "MarkerPosition";
 
-    // George St, Sydney
+    // Default start location: George St, Sydney, Australia
     private static final LatLng SYDNEY = new LatLng(-33.87365, 151.20689);
 
     private StreetViewPanorama streetViewPanorama;
-
+    private GoogleMap map;
     private Marker marker;
+    private FusedLocationProviderClient fusedLocationClient;
+    private CancellationTokenSource cancellationTokenSource;
+    private boolean permissionRequested = false;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(com.example.common_ui.R.layout.split_street_view_panorama_and_map_demo);
+        fusedLocationClient = LocationServices.getFusedLocationProviderClient(this);
 
         final LatLng markerPosition;
         if (savedInstanceState == null) {
@@ -60,6 +91,7 @@ public class SplitStreetViewPanoramaAndMapDemoActivity extends SamplesBaseActivi
             markerPosition = savedInstanceState.getParcelable(MARKER_POSITION_KEY);
         }
 
+        // Initialize the Street View fragment (top pane)
         SupportStreetViewPanoramaFragment streetViewPanoramaFragment =
                 (SupportStreetViewPanoramaFragment)
                         getSupportFragmentManager().findFragmentById(com.example.common_ui.R.id.streetviewpanorama);
@@ -70,50 +102,232 @@ public class SplitStreetViewPanoramaAndMapDemoActivity extends SamplesBaseActivi
                         streetViewPanorama = panorama;
                         streetViewPanorama.setOnStreetViewPanoramaChangeListener(
                                 SplitStreetViewPanoramaAndMapDemoActivity.this);
-                        // Only need to set the position once as the streetview fragment will maintain
-                        // its state.
+                        // Street View maintains its own state across orientation changes; only set position initially.
                         if (savedInstanceState == null) {
                             streetViewPanorama.setPosition(SYDNEY);
                         }
                     }
                 });
 
+        // Initialize the Google Map fragment (bottom pane)
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(com.example.common_ui.R.id.map);
         mapFragment.getMapAsync(new OnMapReadyCallback() {
+            @SuppressLint("MissingPermission")
             @Override
-            public void onMapReady(GoogleMap map) {
-                map.setOnMarkerDragListener(SplitStreetViewPanoramaAndMapDemoActivity.this);
-                // Creates a draggable marker. Long press to drag.
-                marker = map.addMarker(new MarkerOptions()
+            public void onMapReady(GoogleMap googleMap) {
+                map = googleMap;
+                // Center map camera on Pegman's location with street-level zoom
+                googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(markerPosition, 16f));
+                googleMap.setOnMarkerDragListener(SplitStreetViewPanoramaAndMapDemoActivity.this);
+
+                // Hide the default top-right map button in favor of the unified Material FAB
+                googleMap.getUiSettings().setMyLocationButtonEnabled(false);
+                if (hasLocationPermission()) {
+                    googleMap.setMyLocationEnabled(true);
+                }
+
+                // Create a draggable Pegman marker on the map
+                marker = googleMap.addMarker(new MarkerOptions()
                         .position(markerPosition)
                         .icon(BitmapDescriptorFactory.fromResource(com.example.common_ui.R.drawable.pegman))
                         .draggable(true));
             }
         });
+
+        // Material FAB to locate the user and jump Pegman to their neighborhood
+        FloatingActionButton btnMyLocation = findViewById(com.example.common_ui.R.id.btn_my_location);
+        if (btnMyLocation != null) {
+            btnMyLocation.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    moveToMyLocation();
+                }
+            });
+        }
         applyInsets(findViewById(com.example.common_ui.R.id.map_container));
+    }
+
+    /**
+     * Checks if fine or coarse location permission is granted.
+     */
+    private boolean hasLocationPermission() {
+        return ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED
+                || ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Requests high-accuracy live location via {@link FusedLocationProviderClient} and teleports
+     * Pegman, the map camera, and Street View to the user's location.
+     */
+    @SuppressLint("MissingPermission")
+    private void moveToMyLocation() {
+        if (!hasLocationPermission()) {
+            if (permissionRequested && !ActivityCompat.shouldShowRequestPermissionRationale(
+                    this, Manifest.permission.ACCESS_FINE_LOCATION
+            ) && !ActivityCompat.shouldShowRequestPermissionRationale(
+                    this, Manifest.permission.ACCESS_COARSE_LOCATION
+            )) {
+                // Permanently denied ("Don't ask again") -> show informative toast guidance
+                Toast.makeText(
+                        this,
+                        com.example.common_ui.R.string.location_permission_required_toast,
+                        Toast.LENGTH_LONG
+                ).show();
+            } else {
+                permissionRequested = true;
+                PermissionUtils.requestLocationPermissions(this, LOCATION_PERMISSION_REQUEST_CODE, false);
+            }
+            return;
+        }
+
+        if (map != null) {
+            map.setMyLocationEnabled(true);
+        }
+        Toast.makeText(this, getString(com.example.common_ui.R.string.getting_location), Toast.LENGTH_SHORT).show();
+
+        // Cancel any pending active location request
+        if (cancellationTokenSource != null) {
+            cancellationTokenSource.cancel();
+        }
+        cancellationTokenSource = new CancellationTokenSource();
+
+        // Actively query NLP / GNSS for the current high-accuracy position
+        fusedLocationClient.getCurrentLocation(
+                Priority.PRIORITY_HIGH_ACCURACY,
+                cancellationTokenSource.getToken()
+        ).addOnSuccessListener(new OnSuccessListener<Location>() {
+            @Override
+            public void onSuccess(Location location) {
+                if (location != null) {
+                    updatePositionToLocation(location);
+                } else {
+                    // Fallback to last known cached location if live fix is temporarily unavailable
+                    fusedLocationClient.getLastLocation().addOnSuccessListener(new OnSuccessListener<Location>() {
+                        @Override
+                        public void onSuccess(Location fallbackLocation) {
+                            if (fallbackLocation != null) {
+                                updatePositionToLocation(fallbackLocation);
+                            } else {
+                                Toast.makeText(SplitStreetViewPanoramaAndMapDemoActivity.this,
+                                        getString(com.example.common_ui.R.string.waiting_for_location),
+                                        Toast.LENGTH_SHORT).show();
+                            }
+                        }
+                    }).addOnFailureListener(new OnFailureListener() {
+                        @Override
+                        public void onFailure(@NonNull Exception e) {
+                            Toast.makeText(SplitStreetViewPanoramaAndMapDemoActivity.this,
+                                    getString(com.example.common_ui.R.string.waiting_for_location),
+                                    Toast.LENGTH_SHORT).show();
+                        }
+                    });
+                }
+            }
+        }).addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                Toast.makeText(SplitStreetViewPanoramaAndMapDemoActivity.this,
+                        getString(com.example.common_ui.R.string.waiting_for_location),
+                        Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
+    /**
+     * Updates Pegman's position, centers the map camera, and looks up the closest
+     * Street View panorama within a 200m radius of the user coordinates.
+     */
+    private void updatePositionToLocation(Location location) {
+        LatLng userLatLng = new LatLng(location.getLatitude(), location.getLongitude());
+        if (marker != null) {
+            marker.setPosition(userLatLng);
+        }
+        if (map != null) {
+            map.animateCamera(CameraUpdateFactory.newLatLngZoom(userLatLng, 16f));
+        }
+        if (streetViewPanorama != null) {
+            streetViewPanorama.setPosition(userLatLng, 200);
+        }
+        Toast.makeText(this, getString(com.example.common_ui.R.string.moved_pegman_to_location), Toast.LENGTH_SHORT).show();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode != LOCATION_PERMISSION_REQUEST_CODE) {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+            return;
+        }
+        if (PermissionUtils.isPermissionGranted(permissions, grantResults, Manifest.permission.ACCESS_FINE_LOCATION)
+                || PermissionUtils.isPermissionGranted(permissions, grantResults, Manifest.permission.ACCESS_COARSE_LOCATION)) {
+            moveToMyLocation();
+        } else {
+            if (!ActivityCompat.shouldShowRequestPermissionRationale(
+                    this, Manifest.permission.ACCESS_FINE_LOCATION
+            )) {
+                Toast.makeText(
+                        this,
+                        com.example.common_ui.R.string.location_permission_required_toast,
+                        Toast.LENGTH_LONG
+                ).show();
+            }
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (cancellationTokenSource != null) {
+            cancellationTokenSource.cancel();
+        }
     }
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putParcelable(MARKER_POSITION_KEY, marker.getPosition());
+        if (marker != null) {
+            outState.putParcelable(MARKER_POSITION_KEY, marker.getPosition());
+        }
     }
 
+    // --- Street View -> Map Synchronization ---
+
+    /**
+     * Called when the user navigates within the Street View panorama (e.g. stepping down a road).
+     * Synchronizes Pegman's position on the map and smoothly pans the camera.
+     */
     @Override
     public void onStreetViewPanoramaChange(StreetViewPanoramaLocation location) {
         if (location != null) {
-            marker.setPosition(location.position);
+            if (marker != null) {
+                marker.setPosition(location.position);
+            }
+            if (map != null) {
+                map.animateCamera(CameraUpdateFactory.newLatLng(location.position));
+            }
         }
     }
+
+    // --- Map -> Street View Synchronization ---
 
     @Override
     public void onMarkerDragStart(Marker marker) {
     }
 
+    /**
+     * Called when the user finishes dragging Pegman on the map.
+     * Snaps the Street View panorama to the new drop location within a 150m search radius.
+     */
     @Override
     public void onMarkerDragEnd(Marker marker) {
-        streetViewPanorama.setPosition(marker.getPosition(), 150);
+        if (streetViewPanorama != null) {
+            streetViewPanorama.setPosition(marker.getPosition(), 150);
+        }
+        if (map != null) {
+            map.animateCamera(CameraUpdateFactory.newLatLng(marker.getPosition()));
+        }
     }
 
     @Override

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SplitStreetViewPanoramaAndMapDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SplitStreetViewPanoramaAndMapDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,30 +13,67 @@
 // limitations under the License.
 package com.example.kotlindemos
 
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.pm.PackageManager
+import android.location.Location
 import android.os.Bundle
-import android.view.View
+import android.widget.Toast
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.core.os.BundleCompat
 import com.example.common_ui.R
-
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMap.OnMarkerDragListener
 import com.google.android.gms.maps.StreetViewPanorama
 import com.google.android.gms.maps.StreetViewPanorama.OnStreetViewPanoramaChangeListener
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.SupportStreetViewPanoramaFragment
-import com.google.android.gms.maps.model.*
+import com.google.android.gms.maps.model.BitmapDescriptorFactory
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.Marker
+import com.google.android.gms.maps.model.MarkerOptions
+import com.google.android.gms.maps.model.StreetViewPanoramaLocation
+import com.google.android.gms.tasks.CancellationTokenSource
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 
 /**
- * This shows how to create a simple activity with streetview and a map
+ * Demonstrates bidirectional synchronization between a [SupportStreetViewPanoramaFragment]
+ * (top pane) and a [SupportMapFragment] (bottom pane).
+ *
+ * Key concepts illustrated:
+ * 1. **Map-to-Street View Sync**: Long-pressing and dragging the yellow "Pegman" marker on the map
+ *    updates the Street View panorama to match the new drop coordinates.
+ * 2. **Street View-to-Map Sync**: Navigating within Street View (tapping forward arrows/chevrons)
+ *    updates Pegman's position on the map and smoothly pans the map camera to follow.
+ * 3. **High-Accuracy Location**: Uses [FusedLocationProviderClient] with [Priority.PRIORITY_HIGH_ACCURACY]
+ *    to teleport Pegman and Street View to the user's real-time physical location on demand.
  */
 class SplitStreetViewPanoramaAndMapDemoActivity : SamplesBaseActivity(),
-    OnMarkerDragListener, OnStreetViewPanoramaChangeListener {
-    var streetViewPanorama: StreetViewPanorama? = null
-    var marker: Marker? = null
+    OnMarkerDragListener, OnStreetViewPanoramaChangeListener,
+    ActivityCompat.OnRequestPermissionsResultCallback {
+
+    private var streetViewPanorama: StreetViewPanorama? = null
+    private var map: GoogleMap? = null
+    private var marker: Marker? = null
+    private lateinit var fusedLocationClient: FusedLocationProviderClient
+    private var cancellationTokenSource: CancellationTokenSource? = null
+    private var permissionRequested = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.split_street_view_panorama_and_map_demo)
-        val markerPosition = savedInstanceState?.getParcelable(MARKER_POSITION_KEY) ?: SYDNEY
+        fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
 
+        val markerPosition =
+            savedInstanceState?.let { BundleCompat.getParcelable(it, MARKER_POSITION_KEY, LatLng::class.java) }
+                ?: SYDNEY
+
+        // Initialize the Street View fragment (top pane)
         val streetViewPanoramaFragment =
             supportFragmentManager.findFragmentById(R.id.streetviewpanorama) as SupportStreetViewPanoramaFragment?
         streetViewPanoramaFragment?.getStreetViewPanoramaAsync { panorama ->
@@ -44,23 +81,160 @@ class SplitStreetViewPanoramaAndMapDemoActivity : SamplesBaseActivity(),
             streetViewPanorama?.setOnStreetViewPanoramaChangeListener(
                 this@SplitStreetViewPanoramaAndMapDemoActivity
             )
-            // Only need to set the position once as the streetview fragment will maintain
-            // its state.
+            // Street View maintains its own state across orientation changes; only set position initially.
             savedInstanceState ?: streetViewPanorama?.setPosition(SYDNEY)
         }
+
+        // Initialize the Google Map fragment (bottom pane)
         val mapFragment =
             supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
-        mapFragment?.getMapAsync { map ->
-            map.setOnMarkerDragListener(this@SplitStreetViewPanoramaAndMapDemoActivity)
-            // Creates a draggable marker. Long press to drag.
-            marker = map.addMarker(
+        mapFragment?.getMapAsync { googleMap ->
+            map = googleMap
+            // Center map camera on Pegman's location with street-level zoom
+            googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(markerPosition, 16f))
+            googleMap.setOnMarkerDragListener(this@SplitStreetViewPanoramaAndMapDemoActivity)
+
+            // Hide the default top-right map button in favor of the unified Material FAB
+            googleMap.uiSettings.isMyLocationButtonEnabled = false
+            if (hasLocationPermission()) {
+                @SuppressLint("MissingPermission")
+                googleMap.isMyLocationEnabled = true
+            }
+
+            // Create a draggable Pegman marker on the map
+            marker = googleMap.addMarker(
                 MarkerOptions()
                     .position(markerPosition)
                     .icon(BitmapDescriptorFactory.fromResource(R.drawable.pegman))
                     .draggable(true)
             )
         }
-        applyInsets(findViewById<View>(R.id.map_container))
+
+        // Material FAB to locate the user and jump Pegman to their neighborhood
+        findViewById<FloatingActionButton>(R.id.btn_my_location)?.setOnClickListener {
+            moveToMyLocation()
+        }
+        applyInsets(findViewById(R.id.map_container))
+    }
+
+    /**
+     * Checks if fine or coarse location permission is granted.
+     */
+    private fun hasLocationPermission(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            this, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED || ContextCompat.checkSelfPermission(
+            this, Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /**
+     * Requests high-accuracy live location via [FusedLocationProviderClient] and teleports
+     * Pegman, the map camera, and Street View to the user's location.
+     */
+    @SuppressLint("MissingPermission")
+    private fun moveToMyLocation() {
+        if (!hasLocationPermission()) {
+            if (permissionRequested && !ActivityCompat.shouldShowRequestPermissionRationale(
+                    this, Manifest.permission.ACCESS_FINE_LOCATION
+                ) && !ActivityCompat.shouldShowRequestPermissionRationale(
+                    this, Manifest.permission.ACCESS_COARSE_LOCATION
+                )
+            ) {
+                // Permanently denied ("Don't ask again") -> show informative toast guidance
+                Toast.makeText(
+                    this,
+                    R.string.location_permission_required_toast,
+                    Toast.LENGTH_LONG
+                ).show()
+            } else {
+                permissionRequested = true
+                PermissionUtils.requestLocationPermissions(this, LOCATION_PERMISSION_REQUEST_CODE, false)
+            }
+            return
+        }
+
+        map?.isMyLocationEnabled = true
+        Toast.makeText(this, getString(R.string.getting_location), Toast.LENGTH_SHORT).show()
+
+        // Cancel any pending active location request
+        cancellationTokenSource?.cancel()
+        val cts = CancellationTokenSource()
+        cancellationTokenSource = cts
+
+        // Actively query NLP / GNSS for the current high-accuracy position
+        fusedLocationClient.getCurrentLocation(
+            Priority.PRIORITY_HIGH_ACCURACY,
+            cts.token
+        ).addOnSuccessListener { location: Location? ->
+            if (location != null) {
+                updatePositionToLocation(location)
+            } else {
+                // Fallback to last known cached location if live fix is temporarily unavailable
+                fusedLocationClient.lastLocation.addOnSuccessListener { fallbackLocation: Location? ->
+                    if (fallbackLocation != null) {
+                        updatePositionToLocation(fallbackLocation)
+                    } else {
+                        Toast.makeText(this, getString(R.string.waiting_for_location), Toast.LENGTH_SHORT).show()
+                    }
+                }.addOnFailureListener {
+                    Toast.makeText(this, getString(R.string.waiting_for_location), Toast.LENGTH_SHORT).show()
+                }
+            }
+        }.addOnFailureListener {
+            Toast.makeText(this, getString(R.string.waiting_for_location), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /**
+     * Updates Pegman's position, centers the map camera, and looks up the closest
+     * Street View panorama within a 200m radius of the user coordinates.
+     */
+    private fun updatePositionToLocation(location: Location) {
+        val userLatLng = LatLng(location.latitude, location.longitude)
+        marker?.position = userLatLng
+        map?.animateCamera(CameraUpdateFactory.newLatLngZoom(userLatLng, 16f))
+        streetViewPanorama?.setPosition(userLatLng, 200)
+        Toast.makeText(this, getString(R.string.moved_pegman_to_location), Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray
+    ) {
+        if (requestCode != LOCATION_PERMISSION_REQUEST_CODE) {
+            super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+            return
+        }
+        if (PermissionUtils.isPermissionGranted(
+                permissions,
+                grantResults,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) || PermissionUtils.isPermissionGranted(
+                permissions,
+                grantResults,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        ) {
+            moveToMyLocation()
+        } else {
+            if (!ActivityCompat.shouldShowRequestPermissionRationale(
+                    this, Manifest.permission.ACCESS_FINE_LOCATION
+                )
+            ) {
+                Toast.makeText(
+                    this,
+                    R.string.location_permission_required_toast,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cancellationTokenSource?.cancel()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -71,21 +245,37 @@ class SplitStreetViewPanoramaAndMapDemoActivity : SamplesBaseActivity(),
         )
     }
 
+    // --- Street View -> Map Synchronization ---
+
+    /**
+     * Called when the user navigates within the Street View panorama (e.g. stepping down a road).
+     * Synchronizes Pegman's position on the map and smoothly pans the camera.
+     */
     override fun onStreetViewPanoramaChange(location: StreetViewPanoramaLocation) {
         marker?.position = location.position
+        map?.animateCamera(CameraUpdateFactory.newLatLng(location.position))
     }
 
+    // --- Map -> Street View Synchronization ---
+
     override fun onMarkerDragStart(marker: Marker) {}
+
+    /**
+     * Called when the user finishes dragging Pegman on the map.
+     * Snaps the Street View panorama to the new drop location within a 150m search radius.
+     */
     override fun onMarkerDragEnd(marker: Marker) {
         streetViewPanorama?.setPosition(marker.position, 150)
+        map?.animateCamera(CameraUpdateFactory.newLatLng(marker.position))
     }
 
     override fun onMarkerDrag(marker: Marker) {}
 
     companion object {
+        private const val LOCATION_PERMISSION_REQUEST_CODE = 1
         private const val MARKER_POSITION_KEY = "MarkerPosition"
 
-        // George St, Sydney
+        // Default start location: George St, Sydney, Australia
         private val SYDNEY = LatLng(-33.87365, 151.20689)
     }
 }


### PR DESCRIPTION
### Summary

- **My Location FAB**: Add Material 3 Floating Action Button wired to `FusedLocationProviderClient` (`PRIORITY_HIGH_ACCURACY`) with runtime permission handling.
- **Instruction Banner**: Add dismissible instruction banner explaining how touch tracking works.
- **Bidirectional Sync**: Synchronize Pegman marker heading and camera orientation between Map and Panorama.
- **Framing & Docs**: Center initial camera on Sydney Harbour and add literate programming docstrings.

Part of stack: #2390 -> #2391 -> #2392