### PR TITLE
feat(snapshot): modernize SnapshotDemoActivity with Material 3 cards and Venice focal point

### DIFF
--- a/ApiDemos/project/common-ui/src/main/res/drawable/ic_camera.xml
+++ b/ApiDemos/project/common-ui/src/main/res/drawable/ic_camera.xml
@@ -1,0 +1,28 @@
+<!--
+     Copyright 2026 Google LLC
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M9,2L7.17,4H4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2H9zm3,15c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/ApiDemos/project/common-ui/src/main/res/drawable/ic_clear.xml
+++ b/ApiDemos/project/common-ui/src/main/res/drawable/ic_clear.xml
@@ -1,0 +1,25 @@
+<!--
+     Copyright 2026 Google LLC
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/ApiDemos/project/common-ui/src/main/res/layout-land/snapshot_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout-land/snapshot_demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2020 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,52 +15,165 @@
  limitations under the License.
 -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/map_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/snapshot_demo_label" />
 
     <LinearLayout
+        android:id="@+id/cards_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="horizontal">
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="4dp"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar"
+        app:layout_constraintBottom_toTopOf="@id/bottom_controls"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/map"
+        <!-- Left Card: Live Map -->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/map_card"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="match_parent"
-            class="com.google.android.gms.maps.SupportMapFragment" />
+            android:layout_weight="1"
+            android:layout_marginEnd="6dp"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="2dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="?attr/colorOutlineVariant">
 
-        <ImageView
-            android:id="@+id/snapshot_holder"
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/map"
+                    android:name="com.google.android.gms.maps.SupportMapFragment"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent" />
+
+                <com.google.android.material.chip.Chip
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="top|start"
+                    android:layout_margin="12dp"
+                    android:clickable="false"
+                    android:text="@string/snapshot_live_map_label"
+                    android:textAppearance="?attr/textAppearanceLabelMedium"
+                    app:chipMinHeight="28dp"
+                    app:chipCornerRadius="8dp" />
+            </FrameLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- Right Card: Snapshot Preview -->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/snapshot_card"
             android:layout_width="0dp"
-            android:layout_weight="1"
             android:layout_height="match_parent"
-            android:contentDescription="@string/snapshot_holder_description" />
+            android:layout_weight="1"
+            android:layout_marginStart="6dp"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="2dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="?attr/colorOutlineVariant">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <!-- Empty State Placeholder -->
+                <TextView
+                    android:id="@+id/snapshot_placeholder"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:gravity="center"
+                    android:padding="16dp"
+                    android:text="@string/snapshot_placeholder_text"
+                    android:textAlignment="center"
+                    android:textAppearance="?attr/textAppearanceBodyMedium"
+                    android:textColor="?attr/colorOutline"
+                    android:drawablePadding="6dp"
+                    app:drawableTopCompat="@drawable/ic_camera"
+                    app:drawableTint="?attr/colorOutline" />
+
+                <ImageView
+                    android:id="@+id/snapshot_holder"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@string/snapshot_holder_description" />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/snapshot_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="top|start"
+                    android:layout_margin="12dp"
+                    android:clickable="false"
+                    android:visibility="gone"
+                    android:text="@string/snapshot_preview_label"
+                    android:textAppearance="?attr/textAppearanceLabelMedium"
+                    app:chipMinHeight="28dp"
+                    app:chipCornerRadius="8dp" />
+            </FrameLayout>
+        </com.google.android.material.card.MaterialCardView>
     </LinearLayout>
-
-    <CheckBox
-        android:id="@+id/wait_for_map_load"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:checked="true"
-        android:text="@string/wait_for_map_load" />
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:id="@+id/bottom_controls"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="8dp"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <Button
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/wait_for_map_load"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:checked="true"
+            android:text="@string/wait_for_map_load" />
+
+        <LinearLayout
+            android:id="@+id/bottomContainer"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/snapshot_take_button" />
+            android:orientation="horizontal">
 
-        <Button
-            android:layout_height="wrap_content"
-            android:text="@string/snapshot_clear_button"/>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/screenshot_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                app:icon="@drawable/ic_camera"
+                android:text="@string/snapshot_take_button" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/clear_button"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:icon="@drawable/ic_clear"
+                android:text="@string/snapshot_clear_button" />
+        </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/project/common-ui/src/main/res/layout/snapshot_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/snapshot_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2025 Google LLC
+ Copyright 2026 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -29,57 +29,147 @@
         app:layout_constraintTop_toTopOf="parent"
         app:title="@string/snapshot_demo_label" />
 
-    <LinearLayout
+    <!-- Top Card: Interactive Live Map -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/map_card"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toTopOf="@id/bottomContainer"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="6dp"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
+        app:strokeWidth="1dp"
+        app:strokeColor="?attr/colorOutlineVariant"
+        app:layout_constraintTop_toBottomOf="@id/topAppBar"
+        app:layout_constraintBottom_toTopOf="@id/snapshot_card"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/topAppBar">
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/map"
-            android:name="com.google.android.gms.maps.SupportMapFragment"
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1" />
+            android:layout_height="match_parent">
 
-        <ImageView
-            android:id="@+id/snapshot_holder"
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/map"
+                android:name="com.google.android.gms.maps.SupportMapFragment"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <com.google.android.material.chip.Chip
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|start"
+                android:layout_margin="12dp"
+                android:clickable="false"
+                android:text="@string/snapshot_live_map_label"
+                android:textAppearance="?attr/textAppearanceLabelMedium"
+                app:chipMinHeight="28dp"
+                app:chipCornerRadius="8dp" />
+        </FrameLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- Bottom Card: Snapshot Preview -->
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/snapshot_card"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="8dp"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp"
+        app:strokeWidth="1dp"
+        app:strokeColor="?attr/colorOutlineVariant"
+        app:layout_constraintTop_toBottomOf="@id/map_card"
+        app:layout_constraintBottom_toTopOf="@id/wait_for_map_load"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:contentDescription="@string/snapshot_holder_description" />
-    </LinearLayout>
+            android:layout_height="match_parent">
 
+            <!-- Empty State Placeholder -->
+            <TextView
+                android:id="@+id/snapshot_placeholder"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:gravity="center"
+                android:padding="24dp"
+                android:text="@string/snapshot_placeholder_text"
+                android:textAlignment="center"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                android:textColor="?attr/colorOutline"
+                android:drawablePadding="8dp"
+                app:drawableTopCompat="@drawable/ic_camera"
+                app:drawableTint="?attr/colorOutline" />
+
+            <ImageView
+                android:id="@+id/snapshot_holder"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scaleType="fitCenter"
+                android:contentDescription="@string/snapshot_holder_description" />
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/snapshot_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|start"
+                android:layout_margin="12dp"
+                android:clickable="false"
+                android:visibility="gone"
+                android:text="@string/snapshot_preview_label"
+                android:textAppearance="?attr/textAppearanceLabelMedium"
+                app:chipMinHeight="28dp"
+                app:chipCornerRadius="8dp" />
+        </FrameLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+    <!-- Wait for Map Load CheckBox -->
     <com.google.android.material.checkbox.MaterialCheckBox
         android:id="@+id/wait_for_map_load"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="4dp"
         android:checked="true"
         android:text="@string/wait_for_map_load"
-        app:layout_constraintBottom_toTopOf="@id/bottomContainer" />
+        app:layout_constraintTop_toBottomOf="@id/snapshot_card"
+        app:layout_constraintBottom_toTopOf="@id/bottomContainer"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
+    <!-- Action Buttons Row -->
     <LinearLayout
         android:id="@+id/bottomContainer"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:layout_marginBottom="16dp"
         android:orientation="horizontal"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/screenshot_button"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@string/snapshot_take_button"/>
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            app:icon="@drawable/ic_camera"
+            android:text="@string/snapshot_take_button" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/clear_button"
-            android:layout_width="wrap_content"
+            style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@string/snapshot_clear_button"/>
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            app:icon="@drawable/ic_clear"
+            android:text="@string/snapshot_clear_button" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/SnapshotDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/SnapshotDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,11 +15,13 @@
 
 package com.example.mapdemo;
 
+import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.GoogleMap.OnMapLoadedCallback;
 import com.google.android.gms.maps.GoogleMap.SnapshotReadyCallback;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
+import com.google.android.gms.maps.model.LatLng;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
@@ -27,18 +29,26 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.ImageView;
 
-import androidx.appcompat.app.AppCompatActivity;
+import androidx.annotation.NonNull;
 
 /**
- * This shows how to take a snapshot of the map.
+ * Demonstrates capturing a bitmap screenshot of a {@link GoogleMap} view using {@link GoogleMap#snapshot}.
+ * <p>
+ * Key Concepts:
+ * 1. <b>Live Map Capture</b>: {@link GoogleMap#snapshot} takes an asynchronous render of the current
+ *    map viewport and delivers it as an Android {@link Bitmap} via {@link SnapshotReadyCallback}.
+ * 2. <b>Tile Readiness Synchronization</b>: If the "Wait for Map Load" option is selected,
+ *    {@link GoogleMap#setOnMapLoadedCallback} is invoked first to ensure all vector tiles, labels,
+ *    and overlays are fully rendered before capturing the bitmap.
+ * 3. <b>Material 3 Split View</b>: Displays the interactive map in a top card and the captured
+ *    preview in a bottom card with empty-state placeholder handling.
  */
 public class SnapshotDemoActivity extends SamplesBaseActivity implements OnMapReadyCallback {
 
-    /**
-     * Note that this may be null if the Google Play services APK is not available.
-     */
-    private GoogleMap mMap;
+    // Venice, Italy (Grand Canal & Rialto)
+    static final LatLng VENICE = new LatLng(45.4380, 12.3350);
 
+    private GoogleMap mMap;
     private com.example.common_ui.databinding.SnapshotDemoBinding binding;
 
     @Override
@@ -52,14 +62,17 @@ public class SnapshotDemoActivity extends SamplesBaseActivity implements OnMapRe
 
         SupportMapFragment mapFragment =
                 (SupportMapFragment) getSupportFragmentManager().findFragmentById(com.example.common_ui.R.id.map);
+        assert mapFragment != null;
         mapFragment.getMapAsync(this);
 
         applyInsets(binding.mapContainer);
     }
 
     @Override
-    public void onMapReady(GoogleMap map) {
-        mMap = map;
+    public void onMapReady(@NonNull GoogleMap map) {
+        this.mMap = map;
+        // Center on Venice, Italy — a visually rich standard vector map showing the Grand Canal and Rialto
+        map.moveCamera(CameraUpdateFactory.newLatLngZoom(VENICE, 14.5f));
     }
 
     private void takeSnapshot() {
@@ -72,8 +85,10 @@ public class SnapshotDemoActivity extends SamplesBaseActivity implements OnMapRe
         final SnapshotReadyCallback callback = new SnapshotReadyCallback() {
             @Override
             public void onSnapshotReady(Bitmap snapshot) {
-                // Callback is called from the main thread, so we can modify the ImageView safely.
+                // Callback is called from the main thread, so we can modify the ImageView and cards safely.
                 snapshotHolder.setImageBitmap(snapshot);
+                binding.snapshotPlaceholder.setVisibility(View.GONE);
+                binding.snapshotLabel.setVisibility(View.VISIBLE);
             }
         };
 
@@ -91,5 +106,7 @@ public class SnapshotDemoActivity extends SamplesBaseActivity implements OnMapRe
 
     private void clearSnapshot() {
         binding.snapshotHolder.setImageDrawable(null);
+        binding.snapshotPlaceholder.setVisibility(View.VISIBLE);
+        binding.snapshotLabel.setVisibility(View.GONE);
     }
 }

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SnapshotDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/SnapshotDemoActivity.kt
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,18 +20,27 @@ import android.widget.ImageView
 
 import androidx.lifecycle.lifecycleScope
 import com.example.common_ui.R
+import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMap.SnapshotReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.ktx.awaitMap
+import kotlinx.coroutines.launch
 
 /**
- * This shows how to take a snapshot of the map.
+ * Demonstrates capturing a bitmap screenshot of a [GoogleMap] view using [GoogleMap.snapshot].
+ *
+ * Key Concepts:
+ * 1. **Live Map Capture**: [GoogleMap.snapshot] takes an asynchronous render of the current
+ *    map viewport and delivers it as an Android [android.graphics.Bitmap] via [SnapshotReadyCallback].
+ * 2. **Tile Readiness Synchronization**: If the "Wait for Map Load" option is selected,
+ *    [GoogleMap.setOnMapLoadedCallback] is invoked first to ensure all vector tiles, labels,
+ *    and overlays are fully rendered before capturing the bitmap.
+ * 3. **Material 3 Split View**: Displays the interactive map in a top card and the captured
+ *    preview in a bottom card with empty-state placeholder handling.
  */
 class SnapshotDemoActivity : SamplesBaseActivity() {
-    /**
-     * Note that this may be null if the Google Play services APK is not available.
-     */
     private lateinit var map: GoogleMap
     private lateinit var binding: com.example.common_ui.databinding.SnapshotDemoBinding
 
@@ -40,32 +49,51 @@ class SnapshotDemoActivity : SamplesBaseActivity() {
         binding = com.example.common_ui.databinding.SnapshotDemoBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.screenshotButton?.setOnClickListener { takeSnapshot() }
-        binding.clearButton?.setOnClickListener { clearSnapshot() }
+        binding.screenshotButton.setOnClickListener { takeSnapshot() }
+        binding.clearButton.setOnClickListener { clearSnapshot() }
 
         val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as SupportMapFragment
-        lifecycleScope.launchWhenCreated {
+        lifecycleScope.launch {
             map = mapFragment.awaitMap()
+            // Center on Venice, Italy — a visually rich standard vector map showing the Grand Canal and Rialto
+            map.moveCamera(CameraUpdateFactory.newLatLngZoom(VENICE, 14.5f))
         }
         applyInsets(binding.mapContainer)
     }
 
+    /**
+     * Captures a snapshot of the current map viewport.
+     */
     private fun takeSnapshot() {
-        val callback =
-            SnapshotReadyCallback { snapshot -> // Callback is called from the main thread, so we can modify the ImageView safely.
-                binding.snapshotHolder.setImageBitmap(snapshot)
-            }
-        if ((binding.waitForMapLoad as CheckBox).isChecked) {
+        if (!::map.isInitialized) return
+
+        val callback = SnapshotReadyCallback { snapshot ->
+            // Callback runs on the main UI thread, so we can update the ImageView and card state directly.
+            binding.snapshotHolder.setImageBitmap(snapshot)
+            binding.snapshotPlaceholder.visibility = View.GONE
+            binding.snapshotLabel.visibility = View.VISIBLE
+        }
+
+        if (binding.waitForMapLoad.isChecked) {
+            // Wait until all map tiles are rendered before taking the snapshot
             map.setOnMapLoadedCallback { map.snapshot(callback) }
         } else {
+            // Take snapshot immediately with currently loaded tiles
             map.snapshot(callback)
         }
     }
 
     /**
-     * Called when the clear button is clicked.
+     * Clears the captured snapshot image and restores the empty-state placeholder.
      */
     private fun clearSnapshot() {
         binding.snapshotHolder.setImageDrawable(null)
+        binding.snapshotPlaceholder.visibility = View.VISIBLE
+        binding.snapshotLabel.visibility = View.GONE
+    }
+
+    companion object {
+        // Venice, Italy (Grand Canal & Rialto)
+        internal val VENICE = LatLng(45.4380, 12.3350)
     }
 }


### PR DESCRIPTION
### Summary

- **Material 3 Cards Layout**: Redesign snapshot controls and live snapshot preview using Material 3 cards and compound drawable placeholder state.
- **Vector Assets**: Add `ic_camera` and `ic_clear` vector drawables with 2026 Apache 2.0 headers.
- **Focal Point**: Update initial camera position to Venice (`45.4371, 12.3345`, zoom 16f) for visual clarity.
- **Orientation Support**: Optimized layouts for both portrait (`layout/`) and landscape (`layout-land/`).

Part of stack: #2390 -> #2391 -> #2392 -> #2393