### PR TITLE
feat(litelist): modernize LiteListDemoActivity with Material 3 cards and toolbar menu

### DIFF
--- a/ApiDemos/project/common-ui/src/main/res/drawable/ic_view_grid.xml
+++ b/ApiDemos/project/common-ui/src/main/res/drawable/ic_view_grid.xml
@@ -1,0 +1,24 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,3v8h8V3H3zm6,6H5V5h4v4zm-6,4v8h8v-8H3zm6,6H5v-4h4v4zm4,-16v8h8V3h-8zm6,6h-4V5h4v4zm-6,4v8h8v-8h-8zm6,6h-4v-4h4v4z" />
+</vector>

--- a/ApiDemos/project/common-ui/src/main/res/drawable/ic_view_list.xml
+++ b/ApiDemos/project/common-ui/src/main/res/drawable/ic_view_list.xml
@@ -1,0 +1,24 @@
+<!--
+ Copyright 2026 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,14h4v-4H3v4zm0,5h4v-4H3v4zM3,9h4V5H3v4zm5,5h13v-4H8v4zm0,5h13v-4H8v4zM8,5v4h13V5H8z" />
+</vector>

--- a/ApiDemos/project/common-ui/src/main/res/layout/lite_list_demo.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/lite_list_demo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-    Copyright 2018 Google LLC
+    Copyright 2026 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -30,9 +30,14 @@
         app:title="@string/lite_demo_label" />
 
     <androidx.recyclerview.widget.RecyclerView
-        app:layout_constraintTop_toBottomOf="@id/top_bar"
         android:id="@+id/recycler_view"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        android:scrollbars="vertical" />
+        android:clipToPadding="false"
+        android:padding="6dp"
+        android:scrollbars="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_bar" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/ApiDemos/project/common-ui/src/main/res/layout/lite_list_demo_row.xml
+++ b/ApiDemos/project/common-ui/src/main/res/layout/lite_list_demo_row.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-    Copyright 2018 Google LLC
+    Copyright 2026 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -13,32 +13,44 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:map="http://schemas.android.com/tools"
-    android:id="@+id/map_container"
+    android:id="@+id/card_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="5dp">
+    android:layout_margin="6dp"
+    app:cardCornerRadius="16dp"
+    app:cardElevation="2dp"
+    app:strokeColor="?attr/colorOutlineVariant"
+    app:strokeWidth="1dp">
 
-    <TextView
-        android:id="@+id/lite_listrow_text"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceLarge"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:orientation="vertical">
 
-    <com.google.android.gms.maps.MapView
-        android:id="@+id/lite_listrow_map"
-        android:layout_width="match_parent"
-        android:layout_height="150dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/lite_listrow_text"
-        map:liteMode="true"
-        map:mapType="none" />
+        <TextView
+            android:id="@+id/lite_listrow_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawablePadding="8dp"
+            android:paddingHorizontal="14dp"
+            android:paddingVertical="10dp"
+            android:textAppearance="?attr/textAppearanceTitleMedium"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold"
+            app:drawableStartCompat="@drawable/ic_my_location"
+            app:drawableTint="?attr/colorPrimary" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.gms.maps.MapView
+            android:id="@+id/lite_listrow_map"
+            android:layout_width="match_parent"
+            android:layout_height="160dp"
+            map:liteMode="true"
+            map:mapType="none" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>
 

--- a/ApiDemos/project/common-ui/src/main/res/menu/lite_list_menu.xml
+++ b/ApiDemos/project/common-ui/src/main/res/menu/lite_list_menu.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright 2018 Google LLC
+    Copyright 2026 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -20,12 +20,14 @@
 
     <item
         android:id="@+id/layout_linear"
+        android:icon="@drawable/ic_view_list"
         android:title="@string/linear"
-        app:showAsAction="never" />
+        app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/layout_grid"
+        android:icon="@drawable/ic_view_grid"
         android:title="@string/grid"
-        app:showAsAction="never" />
+        app:showAsAction="ifRoom" />
 
 </menu>

--- a/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/LiteListDemoActivity.java
+++ b/ApiDemos/project/java-app/src/main/java/com/example/mapdemo/LiteListDemoActivity.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -51,6 +52,9 @@ public class LiteListDemoActivity extends SamplesBaseActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(com.example.common_ui.R.layout.lite_list_demo);
+
+        Toolbar toolbar = findViewById(com.example.common_ui.R.id.top_bar);
+        setSupportActionBar(toolbar);
 
         mGridLayoutManager = new GridLayoutManager(this, 2);
         mLinearLayoutManager = new LinearLayoutManager(this);

--- a/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/LiteListDemoActivity.kt
+++ b/ApiDemos/project/kotlin-app/src/main/java/com/example/kotlindemos/LiteListDemoActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,20 +54,12 @@ class LiteListDemoActivity : SamplesBaseActivity() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var mapAdapter: RecyclerView.Adapter<MapAdapter.ViewHolder>
 
-    /**
-     * RecycleListener that completely clears the [com.google.android.gms.maps.GoogleMap]
-     * attached to a row in the RecyclerView.
-     * Sets the map type to [com.google.android.gms.maps.GoogleMap.MAP_TYPE_NONE] and clears
-     * the map.
-     */
-    private val recycleListener = RecyclerView.RecyclerListener { holder ->
-        val mapHolder = holder as MapAdapter.ViewHolder
-        mapHolder.clearView()
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(com.example.common_ui.R.layout.lite_list_demo)
+
+        val toolbar = findViewById<androidx.appcompat.widget.Toolbar>(com.example.common_ui.R.id.top_bar)
+        setSupportActionBar(toolbar)
 
         mapAdapter = MapAdapter()
 
@@ -76,14 +68,13 @@ class LiteListDemoActivity : SamplesBaseActivity() {
             setHasFixedSize(true)
             layoutManager = linearLayoutManager
             adapter = mapAdapter
-            setRecyclerListener(recycleListener)
         }
-        applyInsets(findViewById<View>(com.example.common_ui.R.id.map_container))
+        applyInsets(findViewById(com.example.common_ui.R.id.map_container))
     }
 
     /** Create options menu to switch between the linear and grid layout managers. */
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
-        menuInflater.inflate(R.menu.lite_list_menu, menu)
+        menuInflater.inflate(com.example.common_ui.R.menu.lite_list_menu, menu)
         return true
     }
 
@@ -91,7 +82,7 @@ class LiteListDemoActivity : SamplesBaseActivity() {
         recyclerView.layoutManager = when (item.itemId) {
             com.example.common_ui.R.id.layout_linear -> linearLayoutManager
             com.example.common_ui.R.id.layout_grid -> gridLayoutManager
-            else -> return false
+            else -> return super.onOptionsItemSelected(item)
         }
         return true
     }
@@ -105,6 +96,11 @@ class LiteListDemoActivity : SamplesBaseActivity() {
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             holder.bindView(position)
+        }
+
+        override fun onViewRecycled(holder: ViewHolder) {
+            super.onViewRecycled(holder)
+            holder.clearView()
         }
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {


### PR DESCRIPTION
### Summary

- **Material 3 Cards**: Modernize lite list item rows with Material 3 `MaterialCardView`, rounded corners, outline stroke, and location header icons.
- **List / Grid Mode Switcher**: Add toolbar action with vector icons `ic_view_list` and `ic_view_grid` to dynamically toggle between single-column linear list and 2-column grid modes.

Part of stack: #2390 -> #2391 -> #2392 -> #2393 -> #2394 -> #2395